### PR TITLE
Upgrade sns extended client to aws sdk v2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>software.amazon.sns</groupId>
     <artifactId>sns-extended-client</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
     <name>Amazon SNS Extended Client Library for Java</name>
     <description>An extension to the Amazon SNS client that enables sending messages up to 2GB via Amazon S3.
@@ -26,7 +26,7 @@
     </licenses>
 
     <properties>
-        <aws-java-sdk.version>1.11.817</aws-java-sdk.version>
+        <aws-java-sdk.version>2.14.19</aws-java-sdk.version>
     </properties>
 
     <developers>
@@ -53,13 +53,13 @@
             <type>jar</type>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sns</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sns</artifactId>
             <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
             <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>software.amazon.payloadoffloading</groupId>
             <artifactId>payloadoffloading-common</artifactId>
-            <version>1.0.0</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,12 @@
         <dependency>
             <groupId>software.amazon.payloadoffloading</groupId>
             <artifactId>payloadoffloading-common</artifactId>
-            <version>1.1.1</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-sqs-java-extended-client-lib</artifactId>
-            <version>1.1.0</version>
+            <version>2.0.1</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>software.amazon.sns</groupId>
     <artifactId>sns-extended-client</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Amazon SNS Extended Client Library for Java</name>
     <description>An extension to the Amazon SNS client that enables sending messages up to 2GB via Amazon S3.

--- a/pom.xml
+++ b/pom.xml
@@ -139,51 +139,29 @@
                 <version>1.6.7</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://aws.oss.sonatype.org</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <serverId>vy-nexus</serverId>
+                    <nexusUrl>https://nexus.common-services.vydev.io</nexusUrl>
+                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
     <profiles>
         <profile>
             <id>publishing</id>
             <distributionManagement>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://aws.oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
                 <repository>
-                    <id>ossrh</id>
-                    <url>https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                    <uniqueVersion>false</uniqueVersion>
+                    <id>vy-releases</id>
+                    <name>Vy Nexus</name>
+                    <url>https://nexus.common-services.vydev.io/repository/maven-public</url>
+                    <layout>default</layout>
                 </repository>
+                <snapshotRepository>
+                    <id>vy-snapshots</id>
+                    <url>https://nexus.common-services.vydev.io/repository/maven-snapshots-v2</url>
+                </snapshotRepository>
             </distributionManagement>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                                <configuration>
-                                    <gpgArguments>
-                                        <gpgArgument>--pinentry-mode</gpgArgument>
-                                        <gpgArgument>loopback</gpgArgument>
-                                    </gpgArguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>

--- a/src/main/java/software/amazon/sns/AmazonSNSExtendedClient.java
+++ b/src/main/java/software/amazon/sns/AmazonSNSExtendedClient.java
@@ -8,6 +8,8 @@ import org.apache.commons.logging.LogFactory;
 
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sns.model.*;
 import software.amazon.payloadoffloading.*;
@@ -47,7 +49,8 @@ public class AmazonSNSExtendedClient extends AmazonSNSExtendedClientBase {
 
     /**
      * <p>
-     * Sends a message to an Amazon SNS topic or sends a text message (SMS message) directly to a phone number.
+     * Sends a message to an Amazon SNS topic, a text message (SMS message) directly to a phone number, or a message to
+     * a mobile platform endpoint (when you specify the <code>TargetArn</code>).
      * </p>
      * <p>
      * If you send a message to a topic, Amazon SNS delivers the message to each endpoint that is subscribed to the
@@ -64,9 +67,14 @@ public class AmazonSNSExtendedClient extends AmazonSNSExtendedClientBase {
      * </p>
      * <p>
      * For more information about formatting messages, see <a
-     * href="http://docs.aws.amazon.com/sns/latest/dg/mobile-push-send-custommessage.html">Send Custom Platform-Specific
-     * Payloads in Messages to Mobile Devices</a>.
+     * href="https://docs.aws.amazon.com/sns/latest/dg/mobile-push-send-custommessage.html">Send Custom
+     * Platform-Specific Payloads in Messages to Mobile Devices</a>.
      * </p>
+     * <important>
+     * <p>
+     * You can publish messages only to topics and endpoints in the same AWS Region.
+     * </p>
+     * </important>
      *
      * @param publishRequest Input for Publish action.
      * @return Result of the Publish operation returned by the service.
@@ -77,7 +85,24 @@ public class AmazonSNSExtendedClient extends AmazonSNSExtendedClientBase {
      * @throws EndpointDisabledException            Exception error indicating endpoint disabled.
      * @throws PlatformApplicationDisabledException Exception error indicating platform application disabled.
      * @throws AuthorizationErrorException          Indicates that the user has been denied access to the requested resource.
-     * @sample AmazonSNS.Publish
+     * @throws KmsDisabledException                 The request was rejected because the specified customer master key (CMK) isn't enabled.
+     * @throws KmsInvalidStateException             The request was rejected because the state of the specified resource isn't valid for this request. For
+     *                                              more information, see <a href="https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html">How
+     *                                              Key State Affects Use of a Customer Master Key</a> in the <i>AWS Key Management Service Developer
+     *                                              Guide</i>.
+     * @throws KmsNotFoundException                 The request was rejected because the specified entity or resource can't be found.
+     * @throws KmsOptInRequiredException            The AWS access key ID needs a subscription for the service.
+     * @throws KmsThrottlingException               The request was denied due to request throttling. For more information about throttling, see <a
+     *                                              href="https://docs.aws.amazon.com/kms/latest/developerguide/limits.html#requests-per-second">Limits</a>
+     *                                              in the <i>AWS Key Management Service Developer Guide.</i>
+     * @throws KmsAccessDeniedException             The ciphertext references a key that doesn't exist or that you don't have access to.
+     * @throws InvalidSecurityException             The credential signature isn't valid. You must use an HTTPS endpoint and sign your request using
+     *                                              Signature Version 4.
+     * @throws SdkException                         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                              catch all scenarios.
+     * @throws SdkClientException                   If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample SnsClient.Publish
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/Publish" target="_top">AWS API
      * Documentation</a>
      */

--- a/src/main/java/software/amazon/sns/AmazonSNSExtendedClientBase.java
+++ b/src/main/java/software/amazon/sns/AmazonSNSExtendedClientBase.java
@@ -2,15 +2,21 @@ package software.amazon.sns;
 
 import java.util.function.Consumer;
 
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.*;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sns.model.*;
+import software.amazon.awssdk.services.sns.paginators.ListEndpointsByPlatformApplicationIterable;
+import software.amazon.awssdk.services.sns.paginators.ListPlatformApplicationsIterable;
+import software.amazon.awssdk.services.sns.paginators.ListSubscriptionsByTopicIterable;
+import software.amazon.awssdk.services.sns.paginators.ListSubscriptionsIterable;
+import software.amazon.awssdk.services.sns.paginators.ListTopicsIterable;
 
 abstract class AmazonSNSExtendedClientBase implements SnsClient {
-    private final SnsClient amazonSNSToBeExtended;
+    private final SnsClient snsClientToBeExtended;
 
-    public AmazonSNSExtendedClientBase(SnsClient amazonSNSToBeExtended) {
-        this.amazonSNSToBeExtended = amazonSNSToBeExtended;
+    public AmazonSNSExtendedClientBase(SnsClient snsClientToBeExtended) {
+        this.snsClientToBeExtended = snsClientToBeExtended;
     }
 
     /**
@@ -20,15 +26,9 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * href="https://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using Amazon SNS Mobile Push
      * Notifications</a>.
      * </p>
-     * <br/>
-     * <p>
-     * This is a convenience which creates an instance of the {@link GetEndpointAttributesRequest.Builder} avoiding the
-     * need to create one manually via {@link GetEndpointAttributesRequest#builder()}
-     * </p>
      *
      * @param getEndpointAttributesRequest
-     *        A {@link Consumer} that will call methods on {@link GetEndpointAttributesInput.Builder} to create a
-     *        request. Input for GetEndpointAttributes action.
+     *        Input for GetEndpointAttributes action.
      * @return Result of the GetEndpointAttributes operation returned by the service.
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
@@ -43,8 +43,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public GetEndpointAttributesResponse getEndpointAttributes(GetEndpointAttributesRequest getEndpointAttributesRequest) {
-        return amazonSNSToBeExtended.getEndpointAttributes(getEndpointAttributesRequest);
+    public GetEndpointAttributesResponse getEndpointAttributes(GetEndpointAttributesRequest getEndpointAttributesRequest)
+            throws InvalidParameterException, InternalErrorException, AuthorizationErrorException, NotFoundException,
+            AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.getEndpointAttributes(getEndpointAttributesRequest);
     }
 
     /**
@@ -68,8 +70,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public AddPermissionResponse addPermission(AddPermissionRequest addPermissionRequest) {
-        return amazonSNSToBeExtended.addPermission(addPermissionRequest);
+    public AddPermissionResponse addPermission(AddPermissionRequest addPermissionRequest) throws InvalidParameterException,
+            InternalErrorException, AuthorizationErrorException, NotFoundException, AwsServiceException, SdkClientException,
+            SnsException {
+        return snsClientToBeExtended.addPermission(addPermissionRequest);
     }
 
     /**
@@ -97,8 +101,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * target="_top">AWS API Documentation</a>
      */
     @Override
-    public CheckIfPhoneNumberIsOptedOutResponse checkIfPhoneNumberIsOptedOut(CheckIfPhoneNumberIsOptedOutRequest checkIfPhoneNumberIsOptedOutRequest) {
-        return amazonSNSToBeExtended.checkIfPhoneNumberIsOptedOut(checkIfPhoneNumberIsOptedOutRequest);
+    public CheckIfPhoneNumberIsOptedOutResponse checkIfPhoneNumberIsOptedOut(CheckIfPhoneNumberIsOptedOutRequest checkIfPhoneNumberIsOptedOutRequest) throws ThrottledException,
+            InternalErrorException, AuthorizationErrorException, InvalidParameterException, AwsServiceException,
+            SdkClientException, SnsException {
+        return snsClientToBeExtended.checkIfPhoneNumberIsOptedOut(checkIfPhoneNumberIsOptedOutRequest);
     }
 
     /**
@@ -127,8 +133,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public ConfirmSubscriptionResponse confirmSubscription(ConfirmSubscriptionRequest confirmSubscriptionRequest) {
-        return amazonSNSToBeExtended.confirmSubscription(confirmSubscriptionRequest);
+    public ConfirmSubscriptionResponse confirmSubscription(ConfirmSubscriptionRequest confirmSubscriptionRequest)
+            throws SubscriptionLimitExceededException, InvalidParameterException, NotFoundException, InternalErrorException,
+            AuthorizationErrorException, FilterPolicyLimitExceededException, AwsServiceException, SdkClientException,
+            SnsException {
+        return snsClientToBeExtended.confirmSubscription(confirmSubscriptionRequest);
     }
 
     /**
@@ -198,8 +207,9 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * API Documentation</a>
      */
     @Override
-    public CreatePlatformApplicationResponse createPlatformApplication(CreatePlatformApplicationRequest createPlatformApplicationRequest) {
-        return amazonSNSToBeExtended.createPlatformApplication(createPlatformApplicationRequest);
+    public CreatePlatformApplicationResponse createPlatformApplication(CreatePlatformApplicationRequest createPlatformApplicationRequest) throws InvalidParameterException,
+            InternalErrorException, AuthorizationErrorException, AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.createPlatformApplication(createPlatformApplicationRequest);
     }
 
     /**
@@ -236,8 +246,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public CreatePlatformEndpointResponse createPlatformEndpoint(CreatePlatformEndpointRequest createPlatformEndpointRequest) {
-        return amazonSNSToBeExtended.createPlatformEndpoint(createPlatformEndpointRequest);
+    public CreatePlatformEndpointResponse createPlatformEndpoint(CreatePlatformEndpointRequest createPlatformEndpointRequest)
+            throws InvalidParameterException, InternalErrorException, AuthorizationErrorException, NotFoundException,
+            AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.createPlatformEndpoint(createPlatformEndpointRequest);
     }
 
     /**
@@ -270,8 +282,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public CreateTopicResponse createTopic(CreateTopicRequest createTopicRequest) {
-        return amazonSNSToBeExtended.createTopic(createTopicRequest);
+    public CreateTopicResponse createTopic(CreateTopicRequest createTopicRequest) throws InvalidParameterException,
+            TopicLimitExceededException, InternalErrorException, AuthorizationErrorException, InvalidSecurityException,
+            TagLimitExceededException, StaleTagException, TagPolicyException, ConcurrentAccessException, AwsServiceException,
+            SdkClientException, SnsException {
+        return snsClientToBeExtended.createTopic(createTopicRequest);
     }
 
     /**
@@ -299,8 +314,9 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public DeleteEndpointResponse deleteEndpoint(DeleteEndpointRequest deleteEndpointRequest) {
-        return amazonSNSToBeExtended.deleteEndpoint(deleteEndpointRequest);
+    public DeleteEndpointResponse deleteEndpoint(DeleteEndpointRequest deleteEndpointRequest) throws InvalidParameterException,
+            InternalErrorException, AuthorizationErrorException, AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.deleteEndpoint(deleteEndpointRequest);
     }
 
     /**
@@ -325,8 +341,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * API Documentation</a>
      */
     @Override
-    public DeletePlatformApplicationResponse deletePlatformApplication(DeletePlatformApplicationRequest deletePlatformApplicationRequest) {
-        return amazonSNSToBeExtended.deletePlatformApplication(deletePlatformApplicationRequest);
+    public DeletePlatformApplicationResponse deletePlatformApplication(
+            DeletePlatformApplicationRequest deletePlatformApplicationRequest) throws InvalidParameterException,
+            InternalErrorException, AuthorizationErrorException, AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.deletePlatformApplication(deletePlatformApplicationRequest);
     }
 
     /**
@@ -355,8 +373,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public DeleteTopicResponse deleteTopic(DeleteTopicRequest deleteTopicRequest) {
-        return amazonSNSToBeExtended.deleteTopic(deleteTopicRequest);
+    public DeleteTopicResponse deleteTopic(DeleteTopicRequest deleteTopicRequest) throws InvalidParameterException,
+            InternalErrorException, AuthorizationErrorException, NotFoundException, StaleTagException, TagPolicyException,
+            ConcurrentAccessException, AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.deleteTopic(deleteTopicRequest);
     }
 
     /**
@@ -382,8 +402,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * target="_top">AWS API Documentation</a>
      */
     @Override
-    public GetPlatformApplicationAttributesResponse getPlatformApplicationAttributes(GetPlatformApplicationAttributesRequest getPlatformApplicationAttributesRequest) {
-        return amazonSNSToBeExtended.getPlatformApplicationAttributes(getPlatformApplicationAttributesRequest);
+    public GetPlatformApplicationAttributesResponse getPlatformApplicationAttributes(
+            GetPlatformApplicationAttributesRequest getPlatformApplicationAttributesRequest) throws InvalidParameterException,
+            InternalErrorException, AuthorizationErrorException, NotFoundException, AwsServiceException, SdkClientException,
+            SnsException {
+        return snsClientToBeExtended.getPlatformApplicationAttributes(getPlatformApplicationAttributesRequest);
     }
 
     /**
@@ -410,8 +433,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public GetSmsAttributesResponse getSMSAttributes(GetSmsAttributesRequest getSMSAttributesRequest) {
-        return amazonSNSToBeExtended.getSMSAttributes(getSMSAttributesRequest);
+    public GetSmsAttributesResponse getSMSAttributes(GetSmsAttributesRequest getSMSAttributesRequest) throws ThrottledException,
+            InternalErrorException, AuthorizationErrorException, InvalidParameterException, AwsServiceException,
+            SdkClientException, SnsException {
+        return snsClientToBeExtended.getSMSAttributes(getSMSAttributesRequest);
     }
 
     /**
@@ -434,8 +459,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * API Documentation</a>
      */
     @Override
-    public GetSubscriptionAttributesResponse getSubscriptionAttributes(GetSubscriptionAttributesRequest getSubscriptionAttributesRequest) {
-        return amazonSNSToBeExtended.getSubscriptionAttributes(getSubscriptionAttributesRequest);
+    public GetSubscriptionAttributesResponse getSubscriptionAttributes(
+            GetSubscriptionAttributesRequest getSubscriptionAttributesRequest) throws InvalidParameterException,
+            InternalErrorException, NotFoundException, AuthorizationErrorException, AwsServiceException, SdkClientException,
+            SnsException {
+        return snsClientToBeExtended.getSubscriptionAttributes(getSubscriptionAttributesRequest);
     }
 
     /**
@@ -461,8 +489,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public GetTopicAttributesResponse getTopicAttributes(GetTopicAttributesRequest getTopicAttributesRequest) {
-        return amazonSNSToBeExtended.getTopicAttributes(getTopicAttributesRequest);
+    public GetTopicAttributesResponse getTopicAttributes(GetTopicAttributesRequest getTopicAttributesRequest)
+            throws InvalidParameterException, InternalErrorException, NotFoundException, AuthorizationErrorException,
+            InvalidSecurityException, AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.getTopicAttributes(getTopicAttributesRequest);
     }
 
     /**
@@ -495,8 +525,112 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * target="_top">AWS API Documentation</a>
      */
     @Override
-    public ListEndpointsByPlatformApplicationResponse listEndpointsByPlatformApplication(ListEndpointsByPlatformApplicationRequest listEndpointsByPlatformApplicationRequest) {
-        return amazonSNSToBeExtended.listEndpointsByPlatformApplication(listEndpointsByPlatformApplicationRequest);
+    public ListEndpointsByPlatformApplicationResponse listEndpointsByPlatformApplication(
+            ListEndpointsByPlatformApplicationRequest listEndpointsByPlatformApplicationRequest)
+            throws InvalidParameterException, InternalErrorException, AuthorizationErrorException, NotFoundException,
+            AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.listEndpointsByPlatformApplication(listEndpointsByPlatformApplicationRequest);
+    }
+
+    /**
+     * <p>
+     * Lists the endpoints and endpoint attributes for devices in a supported push notification service, such as GCM
+     * (Firebase Cloud Messaging) and APNS. The results for <code>ListEndpointsByPlatformApplication</code> are
+     * paginated and return a limited list of endpoints, up to 100. If additional records are available after the first
+     * page results, then a NextToken string will be returned. To receive the next page, you call
+     * <code>ListEndpointsByPlatformApplication</code> again using the NextToken string received from the previous call.
+     * When there are no more records to return, NextToken will be null. For more information, see <a
+     * href="https://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using Amazon SNS Mobile Push
+     * Notifications</a>.
+     * </p>
+     * <p>
+     * This action is throttled at 30 transactions per second (TPS).
+     * </p>
+     * <br/>
+     * <p>
+     * This is a variant of
+     * {@link #listEndpointsByPlatformApplication(software.amazon.awssdk.services.sns.model.ListEndpointsByPlatformApplicationRequest)}
+     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
+     * internally handle making service calls for you.
+     * </p>
+     * <p>
+     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
+     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
+     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
+     * request, you will see the failures only after you start iterating through the iterable.
+     * </p>
+     *
+     * <p>
+     * The following are few ways to iterate through the response pages:
+     * </p>
+     * 1) Using a Stream
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.sns.paginators.ListEndpointsByPlatformApplicationIterable responses = client.listEndpointsByPlatformApplicationPaginator(request);
+     * responses.stream().forEach(....);
+     * }
+     * </pre>
+     *
+     * 2) Using For loop
+     *
+     * <pre>
+     * {
+     *     &#064;code
+     *     software.amazon.awssdk.services.sns.paginators.ListEndpointsByPlatformApplicationIterable responses = client
+     *             .listEndpointsByPlatformApplicationPaginator(request);
+     *     for (software.amazon.awssdk.services.sns.model.ListEndpointsByPlatformApplicationResponse response : responses) {
+     *         // do something;
+     *     }
+     * }
+     * </pre>
+     *
+     * 3) Use iterator directly
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.sns.paginators.ListEndpointsByPlatformApplicationIterable responses = client.listEndpointsByPlatformApplicationPaginator(request);
+     * responses.iterator().forEachRemaining(....);
+     * }
+     * </pre>
+     * <p>
+     * <b>Please notice that the configuration of null won't limit the number of results you get with the paginator. It
+     * only limits the number of results in each page.</b>
+     * </p>
+     * <p>
+     * <b>Note: If you prefer to have control on service calls, use the
+     * {@link #listEndpointsByPlatformApplication(software.amazon.awssdk.services.sns.model.ListEndpointsByPlatformApplicationRequest)}
+     * operation.</b>
+     * </p>
+     *
+     * @param listEndpointsByPlatformApplicationRequest
+     *        Input for ListEndpointsByPlatformApplication action.
+     * @return A custom iterable that can be used to iterate through all the response pages.
+     * @throws InvalidParameterException
+     *         Indicates that a request parameter does not comply with the associated constraints.
+     * @throws InternalErrorException
+     *         Indicates an internal service error.
+     * @throws AuthorizationErrorException
+     *         Indicates that the user has been denied access to the requested resource.
+     * @throws NotFoundException
+     *         Indicates that the requested resource does not exist.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample SnsClient.ListEndpointsByPlatformApplication
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListEndpointsByPlatformApplication"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public ListEndpointsByPlatformApplicationIterable listEndpointsByPlatformApplicationPaginator(
+            ListEndpointsByPlatformApplicationRequest listEndpointsByPlatformApplicationRequest)
+            throws InvalidParameterException, InternalErrorException, AuthorizationErrorException, NotFoundException,
+            AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.listEndpointsByPlatformApplicationPaginator(listEndpointsByPlatformApplicationRequest);
     }
 
     /**
@@ -527,8 +661,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * API Documentation</a>
      */
     @Override
-    public ListPhoneNumbersOptedOutResponse listPhoneNumbersOptedOut(ListPhoneNumbersOptedOutRequest listPhoneNumbersOptedOutRequest) {
-        return amazonSNSToBeExtended.listPhoneNumbersOptedOut(listPhoneNumbersOptedOutRequest);
+    public ListPhoneNumbersOptedOutResponse listPhoneNumbersOptedOut(
+            ListPhoneNumbersOptedOutRequest listPhoneNumbersOptedOutRequest) throws ThrottledException, InternalErrorException,
+            AuthorizationErrorException, InvalidParameterException, AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.listPhoneNumbersOptedOut(listPhoneNumbersOptedOutRequest);
     }
 
     /**
@@ -560,8 +696,108 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * API Documentation</a>
      */
     @Override
-    public ListPlatformApplicationsResponse listPlatformApplications(ListPlatformApplicationsRequest listPlatformApplicationsRequest) {
-        return amazonSNSToBeExtended.listPlatformApplications(listPlatformApplicationsRequest);
+    public ListPlatformApplicationsResponse listPlatformApplications(
+            ListPlatformApplicationsRequest listPlatformApplicationsRequest) throws InvalidParameterException,
+            InternalErrorException, AuthorizationErrorException, AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.listPlatformApplications(listPlatformApplicationsRequest);
+    }
+
+    /**
+     * <p>
+     * Lists the platform application objects for the supported push notification services, such as APNS and GCM
+     * (Firebase Cloud Messaging). The results for <code>ListPlatformApplications</code> are paginated and return a
+     * limited list of applications, up to 100. If additional records are available after the first page results, then a
+     * NextToken string will be returned. To receive the next page, you call <code>ListPlatformApplications</code> using
+     * the NextToken string received from the previous call. When there are no more records to return,
+     * <code>NextToken</code> will be null. For more information, see <a
+     * href="https://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using Amazon SNS Mobile Push
+     * Notifications</a>.
+     * </p>
+     * <p>
+     * This action is throttled at 15 transactions per second (TPS).
+     * </p>
+     * <br/>
+     * <p>
+     * This is a variant of
+     * {@link #listPlatformApplications(software.amazon.awssdk.services.sns.model.ListPlatformApplicationsRequest)}
+     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
+     * internally handle making service calls for you.
+     * </p>
+     * <p>
+     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
+     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
+     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
+     * request, you will see the failures only after you start iterating through the iterable.
+     * </p>
+     *
+     * <p>
+     * The following are few ways to iterate through the response pages:
+     * </p>
+     * 1) Using a Stream
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.sns.paginators.ListPlatformApplicationsIterable responses = client.listPlatformApplicationsPaginator(request);
+     * responses.stream().forEach(....);
+     * }
+     * </pre>
+     *
+     * 2) Using For loop
+     *
+     * <pre>
+     * {
+     *     &#064;code
+     *     software.amazon.awssdk.services.sns.paginators.ListPlatformApplicationsIterable responses = client
+     *             .listPlatformApplicationsPaginator(request);
+     *     for (software.amazon.awssdk.services.sns.model.ListPlatformApplicationsResponse response : responses) {
+     *         // do something;
+     *     }
+     * }
+     * </pre>
+     *
+     * 3) Use iterator directly
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.sns.paginators.ListPlatformApplicationsIterable responses = client.listPlatformApplicationsPaginator(request);
+     * responses.iterator().forEachRemaining(....);
+     * }
+     * </pre>
+     * <p>
+     * <b>Please notice that the configuration of null won't limit the number of results you get with the paginator. It
+     * only limits the number of results in each page.</b>
+     * </p>
+     * <p>
+     * <b>Note: If you prefer to have control on service calls, use the
+     * {@link #listPlatformApplications(software.amazon.awssdk.services.sns.model.ListPlatformApplicationsRequest)}
+     * operation.</b>
+     * </p>
+     *
+     * @param listPlatformApplicationsRequest
+     *        Input for ListPlatformApplications action.
+     * @return A custom iterable that can be used to iterate through all the response pages.
+     * @throws InvalidParameterException
+     *         Indicates that a request parameter does not comply with the associated constraints.
+     * @throws InternalErrorException
+     *         Indicates an internal service error.
+     * @throws AuthorizationErrorException
+     *         Indicates that the user has been denied access to the requested resource.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample SnsClient.ListPlatformApplications
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListPlatformApplications" target="_top">AWS
+     *      API Documentation</a>
+     */
+    @Override
+    public ListPlatformApplicationsIterable listPlatformApplicationsPaginator(
+            ListPlatformApplicationsRequest listPlatformApplicationsRequest) throws InvalidParameterException,
+            InternalErrorException, AuthorizationErrorException, AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.listPlatformApplicationsPaginator(listPlatformApplicationsRequest);
     }
 
     /**
@@ -588,8 +824,102 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public ListSubscriptionsResponse listSubscriptions(ListSubscriptionsRequest listSubscriptionsRequest) {
-        return amazonSNSToBeExtended.listSubscriptions(listSubscriptionsRequest);
+    public ListSubscriptionsResponse listSubscriptions(ListSubscriptionsRequest listSubscriptionsRequest)
+            throws InvalidParameterException, InternalErrorException, AuthorizationErrorException, AwsServiceException,
+            SdkClientException, SnsException {
+        return snsClientToBeExtended.listSubscriptions(listSubscriptionsRequest);
+    }
+
+    /**
+     * <p>
+     * Returns a list of the requester's subscriptions. Each call returns a limited list of subscriptions, up to 100. If
+     * there are more subscriptions, a <code>NextToken</code> is also returned. Use the <code>NextToken</code> parameter
+     * in a new <code>ListSubscriptions</code> call to get further results.
+     * </p>
+     * <p>
+     * This action is throttled at 30 transactions per second (TPS).
+     * </p>
+     * <br/>
+     * <p>
+     * This is a variant of
+     * {@link #listSubscriptions(software.amazon.awssdk.services.sns.model.ListSubscriptionsRequest)} operation. The
+     * return type is a custom iterable that can be used to iterate through all the pages. SDK will internally handle
+     * making service calls for you.
+     * </p>
+     * <p>
+     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
+     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
+     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
+     * request, you will see the failures only after you start iterating through the iterable.
+     * </p>
+     *
+     * <p>
+     * The following are few ways to iterate through the response pages:
+     * </p>
+     * 1) Using a Stream
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.sns.paginators.ListSubscriptionsIterable responses = client.listSubscriptionsPaginator(request);
+     * responses.stream().forEach(....);
+     * }
+     * </pre>
+     *
+     * 2) Using For loop
+     *
+     * <pre>
+     * {
+     *     &#064;code
+     *     software.amazon.awssdk.services.sns.paginators.ListSubscriptionsIterable responses = client
+     *             .listSubscriptionsPaginator(request);
+     *     for (software.amazon.awssdk.services.sns.model.ListSubscriptionsResponse response : responses) {
+     *         // do something;
+     *     }
+     * }
+     * </pre>
+     *
+     * 3) Use iterator directly
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.sns.paginators.ListSubscriptionsIterable responses = client.listSubscriptionsPaginator(request);
+     * responses.iterator().forEachRemaining(....);
+     * }
+     * </pre>
+     * <p>
+     * <b>Please notice that the configuration of null won't limit the number of results you get with the paginator. It
+     * only limits the number of results in each page.</b>
+     * </p>
+     * <p>
+     * <b>Note: If you prefer to have control on service calls, use the
+     * {@link #listSubscriptions(software.amazon.awssdk.services.sns.model.ListSubscriptionsRequest)} operation.</b>
+     * </p>
+     *
+     * @param listSubscriptionsRequest
+     *        Input for ListSubscriptions action.
+     * @return A custom iterable that can be used to iterate through all the response pages.
+     * @throws InvalidParameterException
+     *         Indicates that a request parameter does not comply with the associated constraints.
+     * @throws InternalErrorException
+     *         Indicates an internal service error.
+     * @throws AuthorizationErrorException
+     *         Indicates that the user has been denied access to the requested resource.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample SnsClient.ListSubscriptions
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListSubscriptions" target="_top">AWS API
+     *      Documentation</a>
+     */
+    @Override
+    public ListSubscriptionsIterable listSubscriptionsPaginator(ListSubscriptionsRequest listSubscriptionsRequest)
+            throws InvalidParameterException, InternalErrorException, AuthorizationErrorException, AwsServiceException,
+            SdkClientException, SnsException {
+        return snsClientToBeExtended.listSubscriptionsPaginator(listSubscriptionsRequest);
     }
 
     /**
@@ -617,8 +947,107 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * API Documentation</a>
      */
     @Override
-    public ListSubscriptionsByTopicResponse listSubscriptionsByTopic(ListSubscriptionsByTopicRequest listSubscriptionsByTopicRequest) {
-        return amazonSNSToBeExtended.listSubscriptionsByTopic(listSubscriptionsByTopicRequest);
+    public ListSubscriptionsByTopicResponse listSubscriptionsByTopic(
+            ListSubscriptionsByTopicRequest listSubscriptionsByTopicRequest) throws InvalidParameterException,
+            InternalErrorException, NotFoundException, AuthorizationErrorException, AwsServiceException, SdkClientException,
+            SnsException {
+        return snsClientToBeExtended.listSubscriptionsByTopic(listSubscriptionsByTopicRequest);
+    }
+
+    /**
+     * <p>
+     * Returns a list of the subscriptions to a specific topic. Each call returns a limited list of subscriptions, up to
+     * 100. If there are more subscriptions, a <code>NextToken</code> is also returned. Use the <code>NextToken</code>
+     * parameter in a new <code>ListSubscriptionsByTopic</code> call to get further results.
+     * </p>
+     * <p>
+     * This action is throttled at 30 transactions per second (TPS).
+     * </p>
+     * <br/>
+     * <p>
+     * This is a variant of
+     * {@link #listSubscriptionsByTopic(software.amazon.awssdk.services.sns.model.ListSubscriptionsByTopicRequest)}
+     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
+     * internally handle making service calls for you.
+     * </p>
+     * <p>
+     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
+     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
+     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
+     * request, you will see the failures only after you start iterating through the iterable.
+     * </p>
+     *
+     * <p>
+     * The following are few ways to iterate through the response pages:
+     * </p>
+     * 1) Using a Stream
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.sns.paginators.ListSubscriptionsByTopicIterable responses = client.listSubscriptionsByTopicPaginator(request);
+     * responses.stream().forEach(....);
+     * }
+     * </pre>
+     *
+     * 2) Using For loop
+     *
+     * <pre>
+     * {
+     *     &#064;code
+     *     software.amazon.awssdk.services.sns.paginators.ListSubscriptionsByTopicIterable responses = client
+     *             .listSubscriptionsByTopicPaginator(request);
+     *     for (software.amazon.awssdk.services.sns.model.ListSubscriptionsByTopicResponse response : responses) {
+     *         // do something;
+     *     }
+     * }
+     * </pre>
+     *
+     * 3) Use iterator directly
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.sns.paginators.ListSubscriptionsByTopicIterable responses = client.listSubscriptionsByTopicPaginator(request);
+     * responses.iterator().forEachRemaining(....);
+     * }
+     * </pre>
+     * <p>
+     * <b>Please notice that the configuration of null won't limit the number of results you get with the paginator. It
+     * only limits the number of results in each page.</b>
+     * </p>
+     * <p>
+     * <b>Note: If you prefer to have control on service calls, use the
+     * {@link #listSubscriptionsByTopic(software.amazon.awssdk.services.sns.model.ListSubscriptionsByTopicRequest)}
+     * operation.</b>
+     * </p>
+     *
+     * @param listSubscriptionsByTopicRequest
+     *        Input for ListSubscriptionsByTopic action.
+     * @return A custom iterable that can be used to iterate through all the response pages.
+     * @throws InvalidParameterException
+     *         Indicates that a request parameter does not comply with the associated constraints.
+     * @throws InternalErrorException
+     *         Indicates an internal service error.
+     * @throws NotFoundException
+     *         Indicates that the requested resource does not exist.
+     * @throws AuthorizationErrorException
+     *         Indicates that the user has been denied access to the requested resource.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample SnsClient.ListSubscriptionsByTopic
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListSubscriptionsByTopic" target="_top">AWS
+     *      API Documentation</a>
+     */
+    @Override
+    public ListSubscriptionsByTopicIterable listSubscriptionsByTopicPaginator(
+            ListSubscriptionsByTopicRequest listSubscriptionsByTopicRequest) throws InvalidParameterException,
+            InternalErrorException, NotFoundException, AuthorizationErrorException, AwsServiceException, SdkClientException,
+            SnsException {
+        return snsClientToBeExtended.listSubscriptionsByTopicPaginator(listSubscriptionsByTopicRequest);
     }
 
     /**
@@ -645,8 +1074,97 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public ListTopicsResponse listTopics(ListTopicsRequest listTopicsRequest) {
-        return amazonSNSToBeExtended.listTopics(listTopicsRequest);
+    public ListTopicsResponse listTopics(ListTopicsRequest listTopicsRequest) throws InvalidParameterException,
+            InternalErrorException, AuthorizationErrorException, AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.listTopics(listTopicsRequest);
+    }
+
+    /**
+     * <p>
+     * Returns a list of the requester's topics. Each call returns a limited list of topics, up to 100. If there are
+     * more topics, a <code>NextToken</code> is also returned. Use the <code>NextToken</code> parameter in a new
+     * <code>ListTopics</code> call to get further results.
+     * </p>
+     * <p>
+     * This action is throttled at 30 transactions per second (TPS).
+     * </p>
+     * <br/>
+     * <p>
+     * This is a variant of {@link #listTopics(software.amazon.awssdk.services.sns.model.ListTopicsRequest)} operation.
+     * The return type is a custom iterable that can be used to iterate through all the pages. SDK will internally
+     * handle making service calls for you.
+     * </p>
+     * <p>
+     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
+     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
+     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
+     * request, you will see the failures only after you start iterating through the iterable.
+     * </p>
+     *
+     * <p>
+     * The following are few ways to iterate through the response pages:
+     * </p>
+     * 1) Using a Stream
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.sns.paginators.ListTopicsIterable responses = client.listTopicsPaginator(request);
+     * responses.stream().forEach(....);
+     * }
+     * </pre>
+     *
+     * 2) Using For loop
+     *
+     * <pre>
+     * {
+     *     &#064;code
+     *     software.amazon.awssdk.services.sns.paginators.ListTopicsIterable responses = client.listTopicsPaginator(request);
+     *     for (software.amazon.awssdk.services.sns.model.ListTopicsResponse response : responses) {
+     *         // do something;
+     *     }
+     * }
+     * </pre>
+     *
+     * 3) Use iterator directly
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.sns.paginators.ListTopicsIterable responses = client.listTopicsPaginator(request);
+     * responses.iterator().forEachRemaining(....);
+     * }
+     * </pre>
+     * <p>
+     * <b>Please notice that the configuration of null won't limit the number of results you get with the paginator. It
+     * only limits the number of results in each page.</b>
+     * </p>
+     * <p>
+     * <b>Note: If you prefer to have control on service calls, use the
+     * {@link #listTopics(software.amazon.awssdk.services.sns.model.ListTopicsRequest)} operation.</b>
+     * </p>
+     *
+     * @param listTopicsRequest
+     * @return A custom iterable that can be used to iterate through all the response pages.
+     * @throws InvalidParameterException
+     *         Indicates that a request parameter does not comply with the associated constraints.
+     * @throws InternalErrorException
+     *         Indicates an internal service error.
+     * @throws AuthorizationErrorException
+     *         Indicates that the user has been denied access to the requested resource.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample SnsClient.ListTopics
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListTopics" target="_top">AWS API
+     *      Documentation</a>
+     */
+    @Override
+    public ListTopicsIterable listTopicsPaginator(ListTopicsRequest listTopicsRequest) throws InvalidParameterException,
+            InternalErrorException, AuthorizationErrorException, AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.listTopicsPaginator(listTopicsRequest);
     }
 
     /**
@@ -674,8 +1192,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public OptInPhoneNumberResponse optInPhoneNumber(OptInPhoneNumberRequest optInPhoneNumberRequest) {
-        return amazonSNSToBeExtended.optInPhoneNumber(optInPhoneNumberRequest);
+    public OptInPhoneNumberResponse optInPhoneNumber(OptInPhoneNumberRequest optInPhoneNumberRequest) throws ThrottledException,
+            InternalErrorException, AuthorizationErrorException, InvalidParameterException, AwsServiceException,
+            SdkClientException, SnsException {
+        return snsClientToBeExtended.optInPhoneNumber(optInPhoneNumberRequest);
     }
 
     /**
@@ -738,8 +1258,12 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public PublishResponse publish(PublishRequest publishRequest) {
-        return amazonSNSToBeExtended.publish(publishRequest);
+    public PublishResponse publish(PublishRequest publishRequest) throws InvalidParameterException,
+            InvalidParameterValueException, InternalErrorException, NotFoundException, EndpointDisabledException,
+            PlatformApplicationDisabledException, AuthorizationErrorException, KmsDisabledException, KmsInvalidStateException,
+            KmsNotFoundException, KmsOptInRequiredException, KmsThrottlingException, KmsAccessDeniedException,
+            InvalidSecurityException, AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.publish(publishRequest);
     }
 
     /**
@@ -762,8 +1286,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public RemovePermissionResponse removePermission(RemovePermissionRequest removePermissionRequest) {
-        return amazonSNSToBeExtended.removePermission(removePermissionRequest);
+    public RemovePermissionResponse removePermission(RemovePermissionRequest removePermissionRequest)
+            throws InvalidParameterException, InternalErrorException, AuthorizationErrorException, NotFoundException,
+            AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.removePermission(removePermissionRequest);
     }
 
     /**
@@ -789,8 +1315,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public SetEndpointAttributesResponse setEndpointAttributes(SetEndpointAttributesRequest setEndpointAttributesRequest) {
-        return amazonSNSToBeExtended.setEndpointAttributes(setEndpointAttributesRequest);
+    public SetEndpointAttributesResponse setEndpointAttributes(SetEndpointAttributesRequest setEndpointAttributesRequest)
+            throws InvalidParameterException, InternalErrorException, AuthorizationErrorException, NotFoundException,
+            AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.setEndpointAttributes(setEndpointAttributesRequest);
     }
 
     /**
@@ -818,8 +1346,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * target="_top">AWS API Documentation</a>
      */
     @Override
-    public SetPlatformApplicationAttributesResponse setPlatformApplicationAttributes(SetPlatformApplicationAttributesRequest setPlatformApplicationAttributesRequest) {
-        return amazonSNSToBeExtended.setPlatformApplicationAttributes(setPlatformApplicationAttributesRequest);
+    public SetPlatformApplicationAttributesResponse setPlatformApplicationAttributes(
+            SetPlatformApplicationAttributesRequest setPlatformApplicationAttributesRequest) throws InvalidParameterException,
+            InternalErrorException, AuthorizationErrorException, NotFoundException, AwsServiceException, SdkClientException,
+            SnsException {
+        return snsClientToBeExtended.setPlatformApplicationAttributes(setPlatformApplicationAttributesRequest);
     }
 
     /**
@@ -849,8 +1380,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public SetSmsAttributesResponse setSMSAttributes(SetSmsAttributesRequest setSMSAttributesRequest) {
-        return amazonSNSToBeExtended.setSMSAttributes(setSMSAttributesRequest);
+    public SetSmsAttributesResponse setSMSAttributes(SetSmsAttributesRequest setSMSAttributesRequest)
+            throws InvalidParameterException, ThrottledException, InternalErrorException, AuthorizationErrorException,
+            AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.setSMSAttributes(setSMSAttributesRequest);
     }
 
     /**
@@ -875,8 +1408,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * API Documentation</a>
      */
     @Override
-    public SetSubscriptionAttributesResponse setSubscriptionAttributes(SetSubscriptionAttributesRequest setSubscriptionAttributesRequest) {
-        return amazonSNSToBeExtended.setSubscriptionAttributes(setSubscriptionAttributesRequest);
+    public SetSubscriptionAttributesResponse setSubscriptionAttributes(
+            SetSubscriptionAttributesRequest setSubscriptionAttributesRequest) throws InvalidParameterException,
+            FilterPolicyLimitExceededException, InternalErrorException, NotFoundException, AuthorizationErrorException,
+            AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.setSubscriptionAttributes(setSubscriptionAttributesRequest);
     }
 
     /**
@@ -901,8 +1437,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public SetTopicAttributesResponse setTopicAttributes(SetTopicAttributesRequest setTopicAttributesRequest) {
-        return amazonSNSToBeExtended.setTopicAttributes(setTopicAttributesRequest);
+    public SetTopicAttributesResponse setTopicAttributes(SetTopicAttributesRequest setTopicAttributesRequest)
+            throws InvalidParameterException, InternalErrorException, NotFoundException, AuthorizationErrorException,
+            InvalidSecurityException, AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.setTopicAttributes(setTopicAttributesRequest);
     }
 
     /**
@@ -939,8 +1477,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public SubscribeResponse subscribe(SubscribeRequest subscribeRequest) {
-        return amazonSNSToBeExtended.subscribe(subscribeRequest);
+    public SubscribeResponse subscribe(SubscribeRequest subscribeRequest) throws SubscriptionLimitExceededException,
+            FilterPolicyLimitExceededException, InvalidParameterException, InternalErrorException, NotFoundException,
+            AuthorizationErrorException, InvalidSecurityException, AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.subscribe(subscribeRequest);
     }
 
     /**
@@ -972,8 +1512,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Documentation</a>
      */
     @Override
-    public UnsubscribeResponse unsubscribe(UnsubscribeRequest unsubscribeRequest) {
-        return amazonSNSToBeExtended.unsubscribe(unsubscribeRequest);
+    public UnsubscribeResponse unsubscribe(UnsubscribeRequest unsubscribeRequest) throws InvalidParameterException,
+        InternalErrorException, AuthorizationErrorException, NotFoundException, InvalidSecurityException,
+        AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.unsubscribe(unsubscribeRequest);
     }
 
     /**
@@ -998,8 +1540,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListTagsForResource" target="_top">AWS API
      *      Documentation</a>     */
     @Override
-    public ListTagsForResourceResponse listTagsForResource(ListTagsForResourceRequest listTagsForResourceRequest) {
-        return amazonSNSToBeExtended.listTagsForResource(listTagsForResourceRequest);
+    public ListTagsForResourceResponse listTagsForResource(ListTagsForResourceRequest listTagsForResourceRequest)
+            throws ResourceNotFoundException, TagPolicyException, InvalidParameterException, AuthorizationErrorException,
+            ConcurrentAccessException, AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.listTagsForResource(listTagsForResourceRequest);
     }
 
     /**
@@ -1060,8 +1604,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/TagResource" target="_top">AWS API
      *      Documentation</a>     */
     @Override
-    public TagResourceResponse tagResource(TagResourceRequest tagResourceRequest) {
-        return amazonSNSToBeExtended.tagResource(tagResourceRequest);
+    public TagResourceResponse tagResource(TagResourceRequest tagResourceRequest) throws ResourceNotFoundException,
+            TagLimitExceededException, StaleTagException, TagPolicyException, InvalidParameterException,
+            AuthorizationErrorException, ConcurrentAccessException, AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.tagResource(tagResourceRequest);
     }
 
     /**
@@ -1089,17 +1635,19 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/UntagResource" target="_top">AWS API
      *      Documentation</a>     */
     @Override
-    public UntagResourceResponse untagResource(UntagResourceRequest untagResourceRequest) {
-        return amazonSNSToBeExtended.untagResource(untagResourceRequest);
+    public UntagResourceResponse untagResource(UntagResourceRequest untagResourceRequest) throws ResourceNotFoundException,
+        TagLimitExceededException, StaleTagException, TagPolicyException, InvalidParameterException,
+        AuthorizationErrorException, ConcurrentAccessException, AwsServiceException, SdkClientException, SnsException {
+        return snsClientToBeExtended.untagResource(untagResourceRequest);
     }
 
     @Override
     public String serviceName() {
-        return amazonSNSToBeExtended.serviceName();
+        return snsClientToBeExtended.serviceName();
     }
 
     @Override
     public void close() {
-        amazonSNSToBeExtended.close();
+        snsClientToBeExtended.close();
     }
 }

--- a/src/main/java/software/amazon/sns/AmazonSNSExtendedClientBase.java
+++ b/src/main/java/software/amazon/sns/AmazonSNSExtendedClientBase.java
@@ -1,21 +1,13 @@
 package software.amazon.sns;
 
-import com.amazonaws.AmazonWebServiceRequest;
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.ResponseMetadata;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.sns.AmazonSNS;
-import com.amazonaws.services.sns.model.*;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.*;
 
-import java.util.List;
+abstract class AmazonSNSExtendedClientBase implements SnsClient {
+    private final SnsClient amazonSNSToBeExtended;
 
-abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
-    private final AmazonSNS amazonSNSToBeExtended;
-
-    public AmazonSNSExtendedClientBase(AmazonSNS amazonSNSToBeExtended) {
+    public AmazonSNSExtendedClientBase(SnsClient amazonSNSToBeExtended) {
         this.amazonSNSToBeExtended = amazonSNSToBeExtended;
     }
 
@@ -32,67 +24,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.GetEndpointAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/GetEndpointAttributes" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public GetEndpointAttributesResult getEndpointAttributes(GetEndpointAttributesRequest getEndpointAttributesRequest) {
+    public GetEndpointAttributesResponse getEndpointAttributes(GetEndpointAttributesRequest getEndpointAttributesRequest) {
         return amazonSNSToBeExtended.getEndpointAttributes(getEndpointAttributesRequest);
-    }
-
-    /**
-     * Overrides the default endpoint for this client ("https://sns.us-east-1.amazonaws.com"). Callers can use this
-     * method to control which AWS region they want to work with.
-     * <p>
-     * Callers can pass in just the endpoint (ex: "sns.us-east-1.amazonaws.com") or a full URL, including the protocol
-     * (ex: "https://sns.us-east-1.amazonaws.com"). If the protocol is not specified here, the default protocol from
-     * this client's {@link ClientConfiguration} will be used, which by default is HTTPS.
-     * <p>
-     * For more information on using AWS regions with the AWS SDK for Java, and a complete list of all available
-     * endpoints for all AWS services, see: <a
-     * href="http://developer.amazonwebservices.com/connect/entry.jspa?externalID=3912">
-     * http://developer.amazonwebservices.com/connect/entry.jspa?externalID=3912</a>
-     * <p>
-     * <b>This method is not threadsafe. An endpoint should be configured when the client is created and before any
-     * service requests are made. Changing it afterwards creates inevitable race conditions for any service requests in
-     * transit or retrying.</b>
-     *
-     * @param endpoint The endpoint (ex: "sns.us-east-1.amazonaws.com") or a full URL, including the protocol (ex:
-     *                 "https://sns.us-east-1.amazonaws.com") of the region specific AWS endpoint this client will communicate
-     *                 with.
-     * @deprecated use {@link AwsClientBuilder#setEndpointConfiguration(AwsClientBuilder.EndpointConfiguration)} for
-     * example:
-     * {@code builder.setEndpointConfiguration(new EndpointConfiguration(endpoint, signingRegion));}
-     */
-    @Override
-    @Deprecated
-    public void setEndpoint(String endpoint) {
-        amazonSNSToBeExtended.setEndpoint(endpoint);
-    }
-
-    /**
-     * An alternative to {@link AmazonSNS#setEndpoint(String)}, sets the regional endpoint for this client's service
-     * calls. Callers can use this method to control which AWS region they want to work with.
-     * <p>
-     * By default, all service endpoints in all regions use the https protocol. To use http instead, specify it in the
-     * {@link ClientConfiguration} supplied at construction.
-     * <p>
-     * <b>This method is not threadsafe. A region should be configured when the client is created and before any service
-     * requests are made. Changing it afterwards creates inevitable race conditions for any service requests in transit
-     * or retrying.</b>
-     *
-     * @param region The region this client will communicate with. See {@link Region#getRegion(Regions)}
-     *               for accessing a given region. Must not be null and must be a region where the service is available.
-     * @see Region#getRegion(Regions)
-     * @see Region#createClient(Class, AWSCredentialsProvider, ClientConfiguration)
-     * @see Region#isServiceSupported(String)
-     * @deprecated use {@link AwsClientBuilder#setRegion(String)}
-     */
-    @Override
-    @Deprecated
-    public void setRegion(Region region) {
-        amazonSNSToBeExtended.setRegion(region);
     }
 
     /**
@@ -107,27 +47,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.AddPermission
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/AddPermission" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public AddPermissionResult addPermission(AddPermissionRequest addPermissionRequest) {
+    public AddPermissionResponse addPermission(AddPermissionRequest addPermissionRequest) {
         return amazonSNSToBeExtended.addPermission(addPermissionRequest);
-    }
-
-    /**
-     * Simplified method form for invoking the AddPermission operation.
-     *
-     * @param topicArn
-     * @param label
-     * @param aWSAccountIds
-     * @param actionNames
-     * @see #addPermission(AddPermissionRequest)
-     */
-    @Override
-    public AddPermissionResult addPermission(String topicArn, String label, List<String> aWSAccountIds, List<String> actionNames) {
-        return amazonSNSToBeExtended.addPermission(topicArn, label, aWSAccountIds, actionNames);
     }
 
     /**
@@ -146,12 +74,14 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.CheckIfPhoneNumberIsOptedOut
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/CheckIfPhoneNumberIsOptedOut"
      * target="_top">AWS API Documentation</a>
      */
     @Override
-    public CheckIfPhoneNumberIsOptedOutResult checkIfPhoneNumberIsOptedOut(CheckIfPhoneNumberIsOptedOutRequest checkIfPhoneNumberIsOptedOutRequest) {
+    public CheckIfPhoneNumberIsOptedOutResponse checkIfPhoneNumberIsOptedOut(CheckIfPhoneNumberIsOptedOutRequest checkIfPhoneNumberIsOptedOutRequest) {
         return amazonSNSToBeExtended.checkIfPhoneNumberIsOptedOut(checkIfPhoneNumberIsOptedOutRequest);
     }
 
@@ -170,38 +100,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws NotFoundException                  Indicates that the requested resource does not exist.
      * @throws InternalErrorException             Indicates an internal service error.
      * @throws AuthorizationErrorException        Indicates that the user has been denied access to the requested resource.
+     * @throws SdkClientException                 If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                       Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.ConfirmSubscription
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ConfirmSubscription" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public ConfirmSubscriptionResult confirmSubscription(ConfirmSubscriptionRequest confirmSubscriptionRequest) {
+    public ConfirmSubscriptionResponse confirmSubscription(ConfirmSubscriptionRequest confirmSubscriptionRequest) {
         return amazonSNSToBeExtended.confirmSubscription(confirmSubscriptionRequest);
-    }
-
-    /**
-     * Simplified method form for invoking the ConfirmSubscription operation.
-     *
-     * @param topicArn
-     * @param token
-     * @param authenticateOnUnsubscribe
-     * @see #confirmSubscription(ConfirmSubscriptionRequest)
-     */
-    @Override
-    public ConfirmSubscriptionResult confirmSubscription(String topicArn, String token, String authenticateOnUnsubscribe) {
-        return amazonSNSToBeExtended.confirmSubscription(topicArn, token, authenticateOnUnsubscribe);
-    }
-
-    /**
-     * Simplified method form for invoking the ConfirmSubscription operation.
-     *
-     * @param topicArn
-     * @param token
-     * @see #confirmSubscription(ConfirmSubscriptionRequest)
-     */
-    @Override
-    public ConfirmSubscriptionResult confirmSubscription(String topicArn, String token) {
-        return amazonSNSToBeExtended.confirmSubscription(topicArn, token);
     }
 
     /**
@@ -238,12 +145,14 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.CreatePlatformApplication
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/CreatePlatformApplication" target="_top">AWS
      * API Documentation</a>
      */
     @Override
-    public CreatePlatformApplicationResult createPlatformApplication(CreatePlatformApplicationRequest createPlatformApplicationRequest) {
+    public CreatePlatformApplicationResponse createPlatformApplication(CreatePlatformApplicationRequest createPlatformApplicationRequest) {
         return amazonSNSToBeExtended.createPlatformApplication(createPlatformApplicationRequest);
     }
 
@@ -272,12 +181,14 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.CreatePlatformEndpoint
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/CreatePlatformEndpoint" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public CreatePlatformEndpointResult createPlatformEndpoint(CreatePlatformEndpointRequest createPlatformEndpointRequest) {
+    public CreatePlatformEndpointResponse createPlatformEndpoint(CreatePlatformEndpointRequest createPlatformEndpointRequest) {
         return amazonSNSToBeExtended.createPlatformEndpoint(createPlatformEndpointRequest);
     }
 
@@ -295,24 +206,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws TopicLimitExceededException Indicates that the customer already owns the maximum allowed number of topics.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.CreateTopic
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/CreateTopic" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public CreateTopicResult createTopic(CreateTopicRequest createTopicRequest) {
+    public CreateTopicResponse createTopic(CreateTopicRequest createTopicRequest) {
         return amazonSNSToBeExtended.createTopic(createTopicRequest);
-    }
-
-    /**
-     * Simplified method form for invoking the CreateTopic operation.
-     *
-     * @param name
-     * @see #createTopic(CreateTopicRequest)
-     */
-    @Override
-    public CreateTopicResult createTopic(String name) {
-        return amazonSNSToBeExtended.createTopic(name);
     }
 
     /**
@@ -331,12 +233,14 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.DeleteEndpoint
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/DeleteEndpoint" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public DeleteEndpointResult deleteEndpoint(DeleteEndpointRequest deleteEndpointRequest) {
+    public DeleteEndpointResponse deleteEndpoint(DeleteEndpointRequest deleteEndpointRequest) {
         return amazonSNSToBeExtended.deleteEndpoint(deleteEndpointRequest);
     }
 
@@ -352,12 +256,14 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.DeletePlatformApplication
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/DeletePlatformApplication" target="_top">AWS
      * API Documentation</a>
      */
     @Override
-    public DeletePlatformApplicationResult deletePlatformApplication(DeletePlatformApplicationRequest deletePlatformApplicationRequest) {
+    public DeletePlatformApplicationResponse deletePlatformApplication(DeletePlatformApplicationRequest deletePlatformApplicationRequest) {
         return amazonSNSToBeExtended.deletePlatformApplication(deletePlatformApplicationRequest);
     }
 
@@ -374,24 +280,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.DeleteTopic
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/DeleteTopic" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public DeleteTopicResult deleteTopic(DeleteTopicRequest deleteTopicRequest) {
+    public DeleteTopicResponse deleteTopic(DeleteTopicRequest deleteTopicRequest) {
         return amazonSNSToBeExtended.deleteTopic(deleteTopicRequest);
-    }
-
-    /**
-     * Simplified method form for invoking the DeleteTopic operation.
-     *
-     * @param topicArn
-     * @see #deleteTopic(DeleteTopicRequest)
-     */
-    @Override
-    public DeleteTopicResult deleteTopic(String topicArn) {
-        return amazonSNSToBeExtended.deleteTopic(topicArn);
     }
 
     /**
@@ -408,12 +305,14 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.GetPlatformApplicationAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/GetPlatformApplicationAttributes"
      * target="_top">AWS API Documentation</a>
      */
     @Override
-    public GetPlatformApplicationAttributesResult getPlatformApplicationAttributes(GetPlatformApplicationAttributesRequest getPlatformApplicationAttributesRequest) {
+    public GetPlatformApplicationAttributesResponse getPlatformApplicationAttributes(GetPlatformApplicationAttributesRequest getPlatformApplicationAttributesRequest) {
         return amazonSNSToBeExtended.getPlatformApplicationAttributes(getPlatformApplicationAttributesRequest);
     }
 
@@ -432,12 +331,14 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.GetSMSAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/GetSMSAttributes" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public GetSMSAttributesResult getSMSAttributes(GetSMSAttributesRequest getSMSAttributesRequest) {
+    public GetSmsAttributesResponse getSMSAttributes(GetSmsAttributesRequest getSMSAttributesRequest) {
         return amazonSNSToBeExtended.getSMSAttributes(getSMSAttributesRequest);
     }
 
@@ -452,24 +353,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.GetSubscriptionAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/GetSubscriptionAttributes" target="_top">AWS
      * API Documentation</a>
      */
     @Override
-    public GetSubscriptionAttributesResult getSubscriptionAttributes(GetSubscriptionAttributesRequest getSubscriptionAttributesRequest) {
+    public GetSubscriptionAttributesResponse getSubscriptionAttributes(GetSubscriptionAttributesRequest getSubscriptionAttributesRequest) {
         return amazonSNSToBeExtended.getSubscriptionAttributes(getSubscriptionAttributesRequest);
-    }
-
-    /**
-     * Simplified method form for invoking the GetSubscriptionAttributes operation.
-     *
-     * @param subscriptionArn
-     * @see #getSubscriptionAttributes(GetSubscriptionAttributesRequest)
-     */
-    @Override
-    public GetSubscriptionAttributesResult getSubscriptionAttributes(String subscriptionArn) {
-        return amazonSNSToBeExtended.getSubscriptionAttributes(subscriptionArn);
     }
 
     /**
@@ -484,24 +376,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.GetTopicAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/GetTopicAttributes" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public GetTopicAttributesResult getTopicAttributes(GetTopicAttributesRequest getTopicAttributesRequest) {
+    public GetTopicAttributesResponse getTopicAttributes(GetTopicAttributesRequest getTopicAttributesRequest) {
         return amazonSNSToBeExtended.getTopicAttributes(getTopicAttributesRequest);
-    }
-
-    /**
-     * Simplified method form for invoking the GetTopicAttributes operation.
-     *
-     * @param topicArn
-     * @see #getTopicAttributes(GetTopicAttributesRequest)
-     */
-    @Override
-    public GetTopicAttributesResult getTopicAttributes(String topicArn) {
-        return amazonSNSToBeExtended.getTopicAttributes(topicArn);
     }
 
     /**
@@ -524,12 +407,14 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.ListEndpointsByPlatformApplication
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListEndpointsByPlatformApplication"
      * target="_top">AWS API Documentation</a>
      */
     @Override
-    public ListEndpointsByPlatformApplicationResult listEndpointsByPlatformApplication(ListEndpointsByPlatformApplicationRequest listEndpointsByPlatformApplicationRequest) {
+    public ListEndpointsByPlatformApplicationResponse listEndpointsByPlatformApplication(ListEndpointsByPlatformApplicationRequest listEndpointsByPlatformApplicationRequest) {
         return amazonSNSToBeExtended.listEndpointsByPlatformApplication(listEndpointsByPlatformApplicationRequest);
     }
 
@@ -552,12 +437,14 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.ListPhoneNumbersOptedOut
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListPhoneNumbersOptedOut" target="_top">AWS
      * API Documentation</a>
      */
     @Override
-    public ListPhoneNumbersOptedOutResult listPhoneNumbersOptedOut(ListPhoneNumbersOptedOutRequest listPhoneNumbersOptedOutRequest) {
+    public ListPhoneNumbersOptedOutResponse listPhoneNumbersOptedOut(ListPhoneNumbersOptedOutRequest listPhoneNumbersOptedOutRequest) {
         return amazonSNSToBeExtended.listPhoneNumbersOptedOut(listPhoneNumbersOptedOutRequest);
     }
 
@@ -580,23 +467,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.ListPlatformApplications
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListPlatformApplications" target="_top">AWS
      * API Documentation</a>
      */
     @Override
-    public ListPlatformApplicationsResult listPlatformApplications(ListPlatformApplicationsRequest listPlatformApplicationsRequest) {
+    public ListPlatformApplicationsResponse listPlatformApplications(ListPlatformApplicationsRequest listPlatformApplicationsRequest) {
         return amazonSNSToBeExtended.listPlatformApplications(listPlatformApplicationsRequest);
-    }
-
-    /**
-     * Simplified method form for invoking the ListPlatformApplications operation.
-     *
-     * @see #listPlatformApplications(ListPlatformApplicationsRequest)
-     */
-    @Override
-    public ListPlatformApplicationsResult listPlatformApplications() {
-        return amazonSNSToBeExtended.listPlatformApplications();
     }
 
     /**
@@ -614,34 +493,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.ListSubscriptions
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListSubscriptions" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public ListSubscriptionsResult listSubscriptions(ListSubscriptionsRequest listSubscriptionsRequest) {
+    public ListSubscriptionsResponse listSubscriptions(ListSubscriptionsRequest listSubscriptionsRequest) {
         return amazonSNSToBeExtended.listSubscriptions(listSubscriptionsRequest);
-    }
-
-    /**
-     * Simplified method form for invoking the ListSubscriptions operation.
-     *
-     * @see #listSubscriptions(ListSubscriptionsRequest)
-     */
-    @Override
-    public ListSubscriptionsResult listSubscriptions() {
-        return amazonSNSToBeExtended.listSubscriptions();
-    }
-
-    /**
-     * Simplified method form for invoking the ListSubscriptions operation.
-     *
-     * @param nextToken
-     * @see #listSubscriptions(ListSubscriptionsRequest)
-     */
-    @Override
-    public ListSubscriptionsResult listSubscriptions(String nextToken) {
-        return amazonSNSToBeExtended.listSubscriptions(nextToken);
     }
 
     /**
@@ -660,36 +520,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.ListSubscriptionsByTopic
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListSubscriptionsByTopic" target="_top">AWS
      * API Documentation</a>
      */
     @Override
-    public ListSubscriptionsByTopicResult listSubscriptionsByTopic(ListSubscriptionsByTopicRequest listSubscriptionsByTopicRequest) {
+    public ListSubscriptionsByTopicResponse listSubscriptionsByTopic(ListSubscriptionsByTopicRequest listSubscriptionsByTopicRequest) {
         return amazonSNSToBeExtended.listSubscriptionsByTopic(listSubscriptionsByTopicRequest);
-    }
-
-    /**
-     * Simplified method form for invoking the ListSubscriptionsByTopic operation.
-     *
-     * @param topicArn
-     * @see #listSubscriptionsByTopic(ListSubscriptionsByTopicRequest)
-     */
-    @Override
-    public ListSubscriptionsByTopicResult listSubscriptionsByTopic(String topicArn) {
-        return amazonSNSToBeExtended.listSubscriptionsByTopic(topicArn);
-    }
-
-    /**
-     * Simplified method form for invoking the ListSubscriptionsByTopic operation.
-     *
-     * @param topicArn
-     * @param nextToken
-     * @see #listSubscriptionsByTopic(ListSubscriptionsByTopicRequest)
-     */
-    @Override
-    public ListSubscriptionsByTopicResult listSubscriptionsByTopic(String topicArn, String nextToken) {
-        return amazonSNSToBeExtended.listSubscriptionsByTopic(topicArn, nextToken);
     }
 
     /**
@@ -707,34 +546,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.ListTopics
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListTopics" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public ListTopicsResult listTopics(ListTopicsRequest listTopicsRequest) {
+    public ListTopicsResponse listTopics(ListTopicsRequest listTopicsRequest) {
         return amazonSNSToBeExtended.listTopics(listTopicsRequest);
-    }
-
-    /**
-     * Simplified method form for invoking the ListTopics operation.
-     *
-     * @see #listTopics(ListTopicsRequest)
-     */
-    @Override
-    public ListTopicsResult listTopics() {
-        return amazonSNSToBeExtended.listTopics();
-    }
-
-    /**
-     * Simplified method form for invoking the ListTopics operation.
-     *
-     * @param nextToken
-     * @see #listTopics(ListTopicsRequest)
-     */
-    @Override
-    public ListTopicsResult listTopics(String nextToken) {
-        return amazonSNSToBeExtended.listTopics(nextToken);
     }
 
     /**
@@ -753,12 +573,14 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.OptInPhoneNumber
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/OptInPhoneNumber" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public OptInPhoneNumberResult optInPhoneNumber(OptInPhoneNumberRequest optInPhoneNumberRequest) {
+    public OptInPhoneNumberResponse optInPhoneNumber(OptInPhoneNumberRequest optInPhoneNumberRequest) {
         return amazonSNSToBeExtended.optInPhoneNumber(optInPhoneNumberRequest);
     }
 
@@ -794,38 +616,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws EndpointDisabledException            Exception error indicating endpoint disabled.
      * @throws PlatformApplicationDisabledException Exception error indicating platform application disabled.
      * @throws AuthorizationErrorException          Indicates that the user has been denied access to the requested resource.
+     * @throws SdkClientException                   If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.Publish
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/Publish" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public PublishResult publish(PublishRequest publishRequest) {
+    public PublishResponse publish(PublishRequest publishRequest) {
         return amazonSNSToBeExtended.publish(publishRequest);
-    }
-
-    /**
-     * Simplified method form for invoking the Publish operation.
-     *
-     * @param topicArn
-     * @param message
-     * @see #publish(PublishRequest)
-     */
-    @Override
-    public PublishResult publish(String topicArn, String message) {
-        return amazonSNSToBeExtended.publish(topicArn, message);
-    }
-
-    /**
-     * Simplified method form for invoking the Publish operation.
-     *
-     * @param topicArn
-     * @param message
-     * @param subject
-     * @see #publish(PublishRequest)
-     */
-    @Override
-    public PublishResult publish(String topicArn, String message, String subject) {
-        return amazonSNSToBeExtended.publish(topicArn, message, subject);
     }
 
     /**
@@ -839,25 +638,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.RemovePermission
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/RemovePermission" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public RemovePermissionResult removePermission(RemovePermissionRequest removePermissionRequest) {
+    public RemovePermissionResponse removePermission(RemovePermissionRequest removePermissionRequest) {
         return amazonSNSToBeExtended.removePermission(removePermissionRequest);
-    }
-
-    /**
-     * Simplified method form for invoking the RemovePermission operation.
-     *
-     * @param topicArn
-     * @param label
-     * @see #removePermission(RemovePermissionRequest)
-     */
-    @Override
-    public RemovePermissionResult removePermission(String topicArn, String label) {
-        return amazonSNSToBeExtended.removePermission(topicArn, label);
     }
 
     /**
@@ -873,12 +662,14 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.SetEndpointAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/SetEndpointAttributes" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public SetEndpointAttributesResult setEndpointAttributes(SetEndpointAttributesRequest setEndpointAttributesRequest) {
+    public SetEndpointAttributesResponse setEndpointAttributes(SetEndpointAttributesRequest setEndpointAttributesRequest) {
         return amazonSNSToBeExtended.setEndpointAttributes(setEndpointAttributesRequest);
     }
 
@@ -897,12 +688,14 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.SetPlatformApplicationAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/SetPlatformApplicationAttributes"
      * target="_top">AWS API Documentation</a>
      */
     @Override
-    public SetPlatformApplicationAttributesResult setPlatformApplicationAttributes(SetPlatformApplicationAttributesRequest setPlatformApplicationAttributesRequest) {
+    public SetPlatformApplicationAttributesResponse setPlatformApplicationAttributes(SetPlatformApplicationAttributesRequest setPlatformApplicationAttributesRequest) {
         return amazonSNSToBeExtended.setPlatformApplicationAttributes(setPlatformApplicationAttributesRequest);
     }
 
@@ -924,12 +717,14 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      *                                     account.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.SetSMSAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/SetSMSAttributes" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public SetSMSAttributesResult setSMSAttributes(SetSMSAttributesRequest setSMSAttributesRequest) {
+    public SetSmsAttributesResponse setSMSAttributes(SetSmsAttributesRequest setSMSAttributesRequest) {
         return amazonSNSToBeExtended.setSMSAttributes(setSMSAttributesRequest);
     }
 
@@ -946,26 +741,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException             Indicates an internal service error.
      * @throws NotFoundException                  Indicates that the requested resource does not exist.
      * @throws AuthorizationErrorException        Indicates that the user has been denied access to the requested resource.
+     * @throws SdkClientException                 If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                       Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.SetSubscriptionAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/SetSubscriptionAttributes" target="_top">AWS
      * API Documentation</a>
      */
     @Override
-    public SetSubscriptionAttributesResult setSubscriptionAttributes(SetSubscriptionAttributesRequest setSubscriptionAttributesRequest) {
+    public SetSubscriptionAttributesResponse setSubscriptionAttributes(SetSubscriptionAttributesRequest setSubscriptionAttributesRequest) {
         return amazonSNSToBeExtended.setSubscriptionAttributes(setSubscriptionAttributesRequest);
-    }
-
-    /**
-     * Simplified method form for invoking the SetSubscriptionAttributes operation.
-     *
-     * @param subscriptionArn
-     * @param attributeName
-     * @param attributeValue
-     * @see #setSubscriptionAttributes(SetSubscriptionAttributesRequest)
-     */
-    @Override
-    public SetSubscriptionAttributesResult setSubscriptionAttributes(String subscriptionArn, String attributeName, String attributeValue) {
-        return amazonSNSToBeExtended.setSubscriptionAttributes(subscriptionArn, attributeName, attributeValue);
     }
 
     /**
@@ -979,26 +763,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.SetTopicAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/SetTopicAttributes" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public SetTopicAttributesResult setTopicAttributes(SetTopicAttributesRequest setTopicAttributesRequest) {
+    public SetTopicAttributesResponse setTopicAttributes(SetTopicAttributesRequest setTopicAttributesRequest) {
         return amazonSNSToBeExtended.setTopicAttributes(setTopicAttributesRequest);
-    }
-
-    /**
-     * Simplified method form for invoking the SetTopicAttributes operation.
-     *
-     * @param topicArn
-     * @param attributeName
-     * @param attributeValue
-     * @see #setTopicAttributes(SetTopicAttributesRequest)
-     */
-    @Override
-    public SetTopicAttributesResult setTopicAttributes(String topicArn, String attributeName, String attributeValue) {
-        return amazonSNSToBeExtended.setTopicAttributes(topicArn, attributeName, attributeValue);
     }
 
     /**
@@ -1020,26 +793,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException             Indicates an internal service error.
      * @throws NotFoundException                  Indicates that the requested resource does not exist.
      * @throws AuthorizationErrorException        Indicates that the user has been denied access to the requested resource.
+     * @throws SdkClientException                 If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                       Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.Subscribe
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/Subscribe" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public SubscribeResult subscribe(SubscribeRequest subscribeRequest) {
+    public SubscribeResponse subscribe(SubscribeRequest subscribeRequest) {
         return amazonSNSToBeExtended.subscribe(subscribeRequest);
-    }
-
-    /**
-     * Simplified method form for invoking the Subscribe operation.
-     *
-     * @param topicArn
-     * @param protocol
-     * @param endpoint
-     * @see #subscribe(SubscribeRequest)
-     */
-    @Override
-    public SubscribeResult subscribe(String topicArn, String protocol, String endpoint) {
-        return amazonSNSToBeExtended.subscribe(topicArn, protocol, endpoint);
     }
 
     /**
@@ -1060,51 +822,15 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
      * @sample AmazonSNS.Unsubscribe
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/Unsubscribe" target="_top">AWS API
      * Documentation</a>
      */
     @Override
-    public UnsubscribeResult unsubscribe(UnsubscribeRequest unsubscribeRequest) {
+    public UnsubscribeResponse unsubscribe(UnsubscribeRequest unsubscribeRequest) {
         return amazonSNSToBeExtended.unsubscribe(unsubscribeRequest);
-    }
-
-    /**
-     * Simplified method form for invoking the Unsubscribe operation.
-     *
-     * @param subscriptionArn
-     * @see #unsubscribe(UnsubscribeRequest)
-     */
-    @Override
-    public UnsubscribeResult unsubscribe(String subscriptionArn) {
-        return amazonSNSToBeExtended.unsubscribe(subscriptionArn);
-    }
-
-    /**
-     * Shuts down this client object, releasing any resources that might be held open. This is an optional method, and
-     * callers are not expected to call it, but can if they want to explicitly release any open resources. Once a client
-     * has been shutdown, it should not be used to make any more requests.
-     */
-    @Override
-    public void shutdown() {
-        amazonSNSToBeExtended.shutdown();
-    }
-
-    /**
-     * Returns additional metadata for a previously executed successful request, typically used for debugging issues
-     * where a service isn't acting as expected. This data isn't considered part of the result data returned by an
-     * operation, so it's available through this separate, diagnostic interface.
-     * <p>
-     * Response metadata is only cached for a limited period of time, so if you need to access this extra diagnostic
-     * information for an executed request, you should use this method to retrieve it as soon as possible after
-     * executing a request.
-     *
-     * @param request The originally executed request.
-     * @return The response metadata for the specified request, or null if none is available.
-     */
-    @Override
-    public ResponseMetadata getCachedResponseMetadata(AmazonWebServiceRequest request) {
-        return amazonSNSToBeExtended.getCachedResponseMetadata(request);
     }
 
     /**
@@ -1114,7 +840,7 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @return Result of the ListTagsForResource operation returned by the service
      */
     @Override
-    public ListTagsForResourceResult listTagsForResource(ListTagsForResourceRequest request) {
+    public ListTagsForResourceResponse listTagsForResource(ListTagsForResourceRequest request) {
         return amazonSNSToBeExtended.listTagsForResource(request);
     }
 
@@ -1125,7 +851,7 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @return Result of the TagResource operation returned by the service.
      */
     @Override
-    public TagResourceResult tagResource(TagResourceRequest request) {
+    public TagResourceResponse tagResource(TagResourceRequest request) {
         return amazonSNSToBeExtended.tagResource(request);
     }
 
@@ -1136,7 +862,17 @@ abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
      * @return Result of the UntagResource operation returned by the service.
      */
     @Override
-    public UntagResourceResult untagResource(UntagResourceRequest request) {
+    public UntagResourceResponse untagResource(UntagResourceRequest request) {
         return amazonSNSToBeExtended.untagResource(request);
+    }
+
+    @Override
+    public String serviceName() {
+        return amazonSNSToBeExtended.serviceName();
+    }
+
+    @Override
+    public void close() {
+        amazonSNSToBeExtended.close();
     }
 }

--- a/src/main/java/software/amazon/sns/AmazonSNSExtendedClientBase.java
+++ b/src/main/java/software/amazon/sns/AmazonSNSExtendedClientBase.java
@@ -1,6 +1,8 @@
 package software.amazon.sns;
 
-import software.amazon.awssdk.core.exception.SdkClientException;
+import java.util.function.Consumer;
+
+import software.amazon.awssdk.core.exception.*;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sns.model.*;
 
@@ -14,19 +16,29 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
     /**
      * <p>
      * Retrieves the endpoint attributes for a device on one of the supported push notification services, such as GCM
-     * and APNS. For more information, see <a href="http://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using
-     * Amazon SNS Mobile Push Notifications</a>.
+     * (Firebase Cloud Messaging) and APNS. For more information, see <a
+     * href="https://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using Amazon SNS Mobile Push
+     * Notifications</a>.
+     * </p>
+     * <br/>
+     * <p>
+     * This is a convenience which creates an instance of the {@link GetEndpointAttributesRequest.Builder} avoiding the
+     * need to create one manually via {@link GetEndpointAttributesRequest#builder()}
      * </p>
      *
-     * @param getEndpointAttributesRequest Input for GetEndpointAttributes action.
+     * @param getEndpointAttributesRequest
+     *        A {@link Consumer} that will call methods on {@link GetEndpointAttributesInput.Builder} to create a
+     *        request. Input for GetEndpointAttributes action.
      * @return Result of the GetEndpointAttributes operation returned by the service.
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.GetEndpointAttributes
+     * @sample SnsClient.GetEndpointAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/GetEndpointAttributes" target="_top">AWS API
      * Documentation</a>
      */
@@ -47,9 +59,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.AddPermission
+     * @sample SnsClient.AddPermission
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/AddPermission" target="_top">AWS API
      * Documentation</a>
      */
@@ -74,9 +88,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.CheckIfPhoneNumberIsOptedOut
+     * @sample SnsClient.CheckIfPhoneNumberIsOptedOut
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/CheckIfPhoneNumberIsOptedOut"
      * target="_top">AWS API Documentation</a>
      */
@@ -100,9 +116,13 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws NotFoundException                  Indicates that the requested resource does not exist.
      * @throws InternalErrorException             Indicates an internal service error.
      * @throws AuthorizationErrorException        Indicates that the user has been denied access to the requested resource.
+     * @throws FilterPolicyLimitExceededException Indicates that the number of filter polices in your AWS account exceeds the limit. To add more filter
+     *                                            polices, submit an SNS Limit Increase case in the AWS Support Center.
+     * @throws SdkException                       Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                            catch all scenarios.
      * @throws SdkClientException                 If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                       Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.ConfirmSubscription
+     * @sample SnsClient.ConfirmSubscription
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ConfirmSubscription" target="_top">AWS API
      * Documentation</a>
      */
@@ -113,31 +133,55 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
 
     /**
      * <p>
-     * Creates a platform application object for one of the supported push notification services, such as APNS and GCM,
-     * to which devices and mobile apps may register. You must specify PlatformPrincipal and PlatformCredential
-     * attributes when using the <code>CreatePlatformApplication</code> action. The PlatformPrincipal is received from
-     * the notification service. For APNS/APNS_SANDBOX, PlatformPrincipal is "SSL certificate". For GCM,
-     * PlatformPrincipal is not applicable. For ADM, PlatformPrincipal is "client id". The PlatformCredential is also
-     * received from the notification service. For WNS, PlatformPrincipal is "Package Security Identifier". For MPNS,
-     * PlatformPrincipal is "TLS certificate". For Baidu, PlatformPrincipal is "API key".
+     * Creates a platform application object for one of the supported push notification services, such as APNS and GCM
+     * (Firebase Cloud Messaging), to which devices and mobile apps may register. You must specify
+     * <code>PlatformPrincipal</code> and <code>PlatformCredential</code> attributes when using the
+     * <code>CreatePlatformApplication</code> action.
      * </p>
      * <p>
-     * For APNS/APNS_SANDBOX, PlatformCredential is "private key". For GCM, PlatformCredential is "API key". For ADM,
-     * PlatformCredential is "client secret". For WNS, PlatformCredential is "secret key". For MPNS, PlatformCredential
-     * is "private key". For Baidu, PlatformCredential is "secret key". The PlatformApplicationArn that is returned when
-     * using <code>CreatePlatformApplication</code> is then used as an attribute for the
-     * <code>CreatePlatformEndpoint</code> action. For more information, see <a
-     * href="http://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using Amazon SNS Mobile Push
-     * Notifications</a>. For more information about obtaining the PlatformPrincipal and PlatformCredential for each of
-     * the supported push notification services, see <a
-     * href="http://docs.aws.amazon.com/sns/latest/dg/mobile-push-apns.html">Getting Started with Apple Push
-     * Notification Service</a>, <a href="http://docs.aws.amazon.com/sns/latest/dg/mobile-push-adm.html">Getting Started
-     * with Amazon Device Messaging</a>, <a
-     * href="http://docs.aws.amazon.com/sns/latest/dg/mobile-push-baidu.html">Getting Started with Baidu Cloud Push</a>,
-     * <a href="http://docs.aws.amazon.com/sns/latest/dg/mobile-push-gcm.html">Getting Started with Google Cloud
-     * Messaging for Android</a>, <a href="http://docs.aws.amazon.com/sns/latest/dg/mobile-push-mpns.html">Getting
-     * Started with MPNS</a>, or <a href="http://docs.aws.amazon.com/sns/latest/dg/mobile-push-wns.html">Getting Started
-     * with WNS</a>.
+     * <code>PlatformPrincipal</code> and <code>PlatformCredential</code> are received from the notification service.
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * For <code>ADM</code>, <code>PlatformPrincipal</code> is <code>client id</code> and
+     * <code>PlatformCredential</code> is <code>client secret</code>.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * For <code>Baidu</code>, <code>PlatformPrincipal</code> is <code>API key</code> and
+     * <code>PlatformCredential</code> is <code>secret key</code>.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * For <code>APNS</code> and <code>APNS_SANDBOX</code>, <code>PlatformPrincipal</code> is
+     * <code>SSL certificate</code> and <code>PlatformCredential</code> is <code>private key</code>.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * For <code>GCM</code> (Firebase Cloud Messaging), there is no <code>PlatformPrincipal</code> and the
+     * <code>PlatformCredential</code> is <code>API key</code>.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * For <code>MPNS</code>, <code>PlatformPrincipal</code> is <code>TLS certificate</code> and
+     * <code>PlatformCredential</code> is <code>private key</code>.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * For <code>WNS</code>, <code>PlatformPrincipal</code> is <code>Package Security Identifier</code> and
+     * <code>PlatformCredential</code> is <code>secret key</code>.
+     * </p>
+     * </li>
+     * </ul>
+     * <p>
+     * You can use the returned <code>PlatformApplicationArn</code> as an attribute for the
+     * <code>CreatePlatformEndpoint</code> action.
      * </p>
      *
      * @param createPlatformApplicationRequest Input for CreatePlatformApplication action.
@@ -145,9 +189,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.CreatePlatformApplication
+     * @sample SnsClient.CreatePlatformApplication
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/CreatePlatformApplication" target="_top">AWS
      * API Documentation</a>
      */
@@ -159,19 +205,19 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
     /**
      * <p>
      * Creates an endpoint for a device and mobile app on one of the supported push notification services, such as GCM
-     * and APNS. <code>CreatePlatformEndpoint</code> requires the PlatformApplicationArn that is returned from
-     * <code>CreatePlatformApplication</code>. The EndpointArn that is returned when using
-     * <code>CreatePlatformEndpoint</code> can then be used by the <code>Publish</code> action to send a message to a
-     * mobile app or by the <code>Subscribe</code> action for subscription to a topic. The
-     * <code>CreatePlatformEndpoint</code> action is idempotent, so if the requester already owns an endpoint with the
-     * same device token and attributes, that endpoint's ARN is returned without creating a new endpoint. For more
-     * information, see <a href="http://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using Amazon SNS Mobile
-     * Push Notifications</a>.
+     * (Firebase Cloud Messaging) and APNS. <code>CreatePlatformEndpoint</code> requires the
+     * <code>PlatformApplicationArn</code> that is returned from <code>CreatePlatformApplication</code>. You can use the
+     * returned <code>EndpointArn</code> to send a message to a mobile app or by the <code>Subscribe</code> action for
+     * subscription to a topic. The <code>CreatePlatformEndpoint</code> action is idempotent, so if the requester
+     * already owns an endpoint with the same device token and attributes, that endpoint's ARN is returned without
+     * creating a new endpoint. For more information, see <a
+     * href="https://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using Amazon SNS Mobile Push
+     * Notifications</a>.
      * </p>
      * <p>
      * When using <code>CreatePlatformEndpoint</code> with Baidu, two attributes must be provided: ChannelId and UserId.
      * The token field must also contain the ChannelId. For more information, see <a
-     * href="http://docs.aws.amazon.com/sns/latest/dg/SNSMobilePushBaiduEndpoint.html">Creating an Amazon SNS Endpoint
+     * href="https://docs.aws.amazon.com/sns/latest/dg/SNSMobilePushBaiduEndpoint.html">Creating an Amazon SNS Endpoint
      * for Baidu</a>.
      * </p>
      *
@@ -181,9 +227,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.CreatePlatformEndpoint
+     * @sample SnsClient.CreatePlatformEndpoint
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/CreatePlatformEndpoint" target="_top">AWS API
      * Documentation</a>
      */
@@ -195,7 +243,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
     /**
      * <p>
      * Creates a topic to which notifications can be published. Users can create at most 100,000 topics. For more
-     * information, see <a href="http://aws.amazon.com/sns/">http://aws.amazon.com/sns</a>. This action is idempotent,
+     * information, see <a href="http://aws.amazon.com/sns/">https://aws.amazon.com/sns</a>. This action is idempotent,
      * so if the requester already owns a topic with the specified name, that topic's ARN is returned without creating a
      * new topic.
      * </p>
@@ -206,9 +254,18 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws TopicLimitExceededException Indicates that the customer already owns the maximum allowed number of topics.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws InvalidSecurityException    The credential signature isn't valid. You must use an HTTPS endpoint and sign your request using
+     *                                     Signature Version 4.
+     * @throws TagLimitExceededException   Can't add more than 50 tags to a topic.
+     * @throws StaleTagException           A tag has been added to a resource with the same ARN as a deleted resource. Wait a short while and then
+     *                                     retry the operation.
+     * @throws TagPolicyException          The request doesn't comply with the IAM tag policy. Correct your request and then retry it.
+     * @throws ConcurrentAccessException   Can't perform multiple operations on a tag simultaneously. Perform the operations sequentially.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.CreateTopic
+     * @sample SnsClient.CreateTopic
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/CreateTopic" target="_top">AWS API
      * Documentation</a>
      */
@@ -220,7 +277,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
     /**
      * <p>
      * Deletes the endpoint for a device and mobile app from Amazon SNS. This action is idempotent. For more
-     * information, see <a href="http://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using Amazon SNS Mobile
+     * information, see <a href="https://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using Amazon SNS Mobile
      * Push Notifications</a>.
      * </p>
      * <p>
@@ -233,9 +290,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.DeleteEndpoint
+     * @sample SnsClient.DeleteEndpoint
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/DeleteEndpoint" target="_top">AWS API
      * Documentation</a>
      */
@@ -246,9 +305,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
 
     /**
      * <p>
-     * Deletes a platform application object for one of the supported push notification services, such as APNS and GCM.
-     * For more information, see <a href="http://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using Amazon SNS
-     * Mobile Push Notifications</a>.
+     * Deletes a platform application object for one of the supported push notification services, such as APNS and GCM
+     * (Firebase Cloud Messaging). For more information, see <a
+     * href="https://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using Amazon SNS Mobile Push
+     * Notifications</a>.
      * </p>
      *
      * @param deletePlatformApplicationRequest Input for DeletePlatformApplication action.
@@ -256,9 +316,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.DeletePlatformApplication
+     * @sample SnsClient.DeletePlatformApplication
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/DeletePlatformApplication" target="_top">AWS
      * API Documentation</a>
      */
@@ -280,9 +342,15 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws StaleTagException           A tag has been added to a resource with the same ARN as a deleted resource. Wait a short while and then
+     *                                     retry the operation.
+     * @throws TagPolicyException          The request doesn't comply with the IAM tag policy. Correct your request and then retry it.
+     * @throws ConcurrentAccessException   Can't perform multiple operations on a tag simultaneously. Perform the operations sequentially.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.DeleteTopic
+     * @sample SnsClient.DeleteTopic
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/DeleteTopic" target="_top">AWS API
      * Documentation</a>
      */
@@ -305,9 +373,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.GetPlatformApplicationAttributes
+     * @sample SnsClient.GetPlatformApplicationAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/GetPlatformApplicationAttributes"
      * target="_top">AWS API Documentation</a>
      */
@@ -331,9 +401,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.GetSMSAttributes
+     * @sample SnsClient.GetSMSAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/GetSMSAttributes" target="_top">AWS API
      * Documentation</a>
      */
@@ -353,9 +425,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.GetSubscriptionAttributes
+     * @sample SnsClient.GetSubscriptionAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/GetSubscriptionAttributes" target="_top">AWS
      * API Documentation</a>
      */
@@ -376,9 +450,13 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws InvalidSecurityException    The credential signature isn't valid. You must use an HTTPS endpoint and sign your request using
+     *                                     Signature Version 4.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.GetTopicAttributes
+     * @sample SnsClient.GetTopicAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/GetTopicAttributes" target="_top">AWS API
      * Documentation</a>
      */
@@ -389,13 +467,14 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
 
     /**
      * <p>
-     * Lists the endpoints and endpoint attributes for devices in a supported push notification service, such as GCM and
-     * APNS. The results for <code>ListEndpointsByPlatformApplication</code> are paginated and return a limited list of
-     * endpoints, up to 100. If additional records are available after the first page results, then a NextToken string
-     * will be returned. To receive the next page, you call <code>ListEndpointsByPlatformApplication</code> again using
-     * the NextToken string received from the previous call. When there are no more records to return, NextToken will be
-     * null. For more information, see <a href="http://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using
-     * Amazon SNS Mobile Push Notifications</a>.
+     * Lists the endpoints and endpoint attributes for devices in a supported push notification service, such as GCM
+     * (Firebase Cloud Messaging) and APNS. The results for <code>ListEndpointsByPlatformApplication</code> are
+     * paginated and return a limited list of endpoints, up to 100. If additional records are available after the first
+     * page results, then a NextToken string will be returned. To receive the next page, you call
+     * <code>ListEndpointsByPlatformApplication</code> again using the NextToken string received from the previous call.
+     * When there are no more records to return, NextToken will be null. For more information, see <a
+     * href="https://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using Amazon SNS Mobile Push
+     * Notifications</a>.
      * </p>
      * <p>
      * This action is throttled at 30 transactions per second (TPS).
@@ -407,9 +486,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.ListEndpointsByPlatformApplication
+     * @sample SnsClient.ListEndpointsByPlatformApplication
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListEndpointsByPlatformApplication"
      * target="_top">AWS API Documentation</a>
      */
@@ -437,9 +518,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.ListPhoneNumbersOptedOut
+     * @sample SnsClient.ListPhoneNumbersOptedOut
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListPhoneNumbersOptedOut" target="_top">AWS
      * API Documentation</a>
      */
@@ -450,12 +533,13 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
 
     /**
      * <p>
-     * Lists the platform application objects for the supported push notification services, such as APNS and GCM. The
-     * results for <code>ListPlatformApplications</code> are paginated and return a limited list of applications, up to
-     * 100. If additional records are available after the first page results, then a NextToken string will be returned.
-     * To receive the next page, you call <code>ListPlatformApplications</code> using the NextToken string received from
-     * the previous call. When there are no more records to return, NextToken will be null. For more information, see <a
-     * href="http://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using Amazon SNS Mobile Push
+     * Lists the platform application objects for the supported push notification services, such as APNS and GCM
+     * (Firebase Cloud Messaging). The results for <code>ListPlatformApplications</code> are paginated and return a
+     * limited list of applications, up to 100. If additional records are available after the first page results, then a
+     * NextToken string will be returned. To receive the next page, you call <code>ListPlatformApplications</code> using
+     * the NextToken string received from the previous call. When there are no more records to return,
+     * <code>NextToken</code> will be null. For more information, see <a
+     * href="https://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using Amazon SNS Mobile Push
      * Notifications</a>.
      * </p>
      * <p>
@@ -467,9 +551,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.ListPlatformApplications
+     * @sample SnsClient.ListPlatformApplications
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListPlatformApplications" target="_top">AWS
      * API Documentation</a>
      */
@@ -493,9 +579,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.ListSubscriptions
+     * @sample SnsClient.ListSubscriptions
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListSubscriptions" target="_top">AWS API
      * Documentation</a>
      */
@@ -520,9 +608,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.ListSubscriptionsByTopic
+     * @sample SnsClient.ListSubscriptionsByTopic
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListSubscriptionsByTopic" target="_top">AWS
      * API Documentation</a>
      */
@@ -546,9 +636,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.ListTopics
+     * @sample SnsClient.ListTopics
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListTopics" target="_top">AWS API
      * Documentation</a>
      */
@@ -573,9 +665,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.OptInPhoneNumber
+     * @sample SnsClient.OptInPhoneNumber
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/OptInPhoneNumber" target="_top">AWS API
      * Documentation</a>
      */
@@ -586,7 +680,8 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
 
     /**
      * <p>
-     * Sends a message to an Amazon SNS topic or sends a text message (SMS message) directly to a phone number.
+     * Sends a message to an Amazon SNS topic, a text message (SMS message) directly to a phone number, or a message to
+     * a mobile platform endpoint (when you specify the <code>TargetArn</code>).
      * </p>
      * <p>
      * If you send a message to a topic, Amazon SNS delivers the message to each endpoint that is subscribed to the
@@ -603,9 +698,14 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * </p>
      * <p>
      * For more information about formatting messages, see <a
-     * href="http://docs.aws.amazon.com/sns/latest/dg/mobile-push-send-custommessage.html">Send Custom Platform-Specific
-     * Payloads in Messages to Mobile Devices</a>.
+     * href="https://docs.aws.amazon.com/sns/latest/dg/mobile-push-send-custommessage.html">Send Custom
+     * Platform-Specific Payloads in Messages to Mobile Devices</a>.
      * </p>
+     * <important>
+     * <p>
+     * You can publish messages only to topics and endpoints in the same AWS Region.
+     * </p>
+     * </important>
      *
      * @param publishRequest Input for Publish action.
      * @return Result of the Publish operation returned by the service.
@@ -616,9 +716,24 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws EndpointDisabledException            Exception error indicating endpoint disabled.
      * @throws PlatformApplicationDisabledException Exception error indicating platform application disabled.
      * @throws AuthorizationErrorException          Indicates that the user has been denied access to the requested resource.
+     * @throws KmsDisabledException                 The request was rejected because the specified customer master key (CMK) isn't enabled.
+     * @throws KmsInvalidStateException             The request was rejected because the state of the specified resource isn't valid for this request. For
+     *                                              more information, see <a href="https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html">How
+     *                                              Key State Affects Use of a Customer Master Key</a> in the <i>AWS Key Management Service Developer
+     *                                              Guide</i>.
+     * @throws KmsNotFoundException                 The request was rejected because the specified entity or resource can't be found.
+     * @throws KmsOptInRequiredException            The AWS access key ID needs a subscription for the service.
+     * @throws KmsThrottlingException               The request was denied due to request throttling. For more information about throttling, see <a
+                                                    href="https://docs.aws.amazon.com/kms/latest/developerguide/limits.html#requests-per-second">Limits</a>
+     *                                              in the <i>AWS Key Management Service Developer Guide.</i>
+     * @throws KmsAccessDeniedException             The ciphertext references a key that doesn't exist or that you don't have access to.
+     * @throws InvalidSecurityException             The credential signature isn't valid. You must use an HTTPS endpoint and sign your request using
+     *                                              Signature Version 4.
+     * @throws SdkException                         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                              catch all scenarios.
      * @throws SdkClientException                   If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.Publish
+     * @sample SnsClient.Publish
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/Publish" target="_top">AWS API
      * Documentation</a>
      */
@@ -638,9 +753,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.RemovePermission
+     * @sample SnsClient.RemovePermission
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/RemovePermission" target="_top">AWS API
      * Documentation</a>
      */
@@ -652,8 +769,9 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
     /**
      * <p>
      * Sets the attributes for an endpoint for a device on one of the supported push notification services, such as GCM
-     * and APNS. For more information, see <a href="http://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using
-     * Amazon SNS Mobile Push Notifications</a>.
+     * (Firebase Cloud Messaging) and APNS. For more information, see <a
+     * href="https://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using Amazon SNS Mobile Push
+     * Notifications</a>.
      * </p>
      *
      * @param setEndpointAttributesRequest Input for SetEndpointAttributes action.
@@ -662,9 +780,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.SetEndpointAttributes
+     * @sample SnsClient.SetEndpointAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/SetEndpointAttributes" target="_top">AWS API
      * Documentation</a>
      */
@@ -676,10 +796,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
     /**
      * <p>
      * Sets the attributes of the platform application object for the supported push notification services, such as APNS
-     * and GCM. For more information, see <a href="http://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using
-     * Amazon SNS Mobile Push Notifications</a>. For information on configuring attributes for message delivery status,
-     * see <a href="http://docs.aws.amazon.com/sns/latest/dg/sns-msg-status.html">Using Amazon SNS Application
-     * Attributes for Message Delivery Status</a>.
+     * and GCM (Firebase Cloud Messaging). For more information, see <a
+     * href="https://docs.aws.amazon.com/sns/latest/dg/SNSMobilePush.html">Using Amazon SNS Mobile Push
+     * Notifications</a>. For information on configuring attributes for message delivery status, see <a
+     * href="https://docs.aws.amazon.com/sns/latest/dg/sns-msg-status.html">Using Amazon SNS Application Attributes for
+     * Message Delivery Status</a>.
      * </p>
      *
      * @param setPlatformApplicationAttributesRequest Input for SetPlatformApplicationAttributes action.
@@ -688,9 +809,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.SetPlatformApplicationAttributes
+     * @sample SnsClient.SetPlatformApplicationAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/SetPlatformApplicationAttributes"
      * target="_top">AWS API Documentation</a>
      */
@@ -706,7 +829,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * <p>
      * You can override some of these settings for a single message when you use the <code>Publish</code> action with
      * the <code>MessageAttributes.entry.N</code> parameter. For more information, see <a
-     * href="http://docs.aws.amazon.com/sns/latest/dg/sms_publish-to-phone.html">Sending an SMS Message</a> in the
+     * href="https://docs.aws.amazon.com/sns/latest/dg/sms_publish-to-phone.html">Sending an SMS Message</a> in the
      * <i>Amazon SNS Developer Guide</i>.
      * </p>
      *
@@ -717,9 +840,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      *                                     account.
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.SetSMSAttributes
+     * @sample SnsClient.SetSMSAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/SetSMSAttributes" target="_top">AWS API
      * Documentation</a>
      */
@@ -741,9 +866,11 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException             Indicates an internal service error.
      * @throws NotFoundException                  Indicates that the requested resource does not exist.
      * @throws AuthorizationErrorException        Indicates that the user has been denied access to the requested resource.
+     * @throws SdkException                       Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                            catch all scenarios.
      * @throws SdkClientException                 If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                       Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.SetSubscriptionAttributes
+     * @sample SnsClient.SetSubscriptionAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/SetSubscriptionAttributes" target="_top">AWS
      * API Documentation</a>
      */
@@ -763,9 +890,13 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws InvalidSecurityException    The credential signature isn't valid. You must use an HTTPS endpoint and sign your request using
+     *                                     Signature Version 4.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.SetTopicAttributes
+     * @sample SnsClient.SetTopicAttributes
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/SetTopicAttributes" target="_top">AWS API
      * Documentation</a>
      */
@@ -776,9 +907,13 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
 
     /**
      * <p>
-     * Prepares to subscribe an endpoint by sending the endpoint a confirmation message. To actually create a
-     * subscription, the endpoint owner must call the <code>ConfirmSubscription</code> action with the token from the
-     * confirmation message. Confirmation tokens are valid for three days.
+     * Subscribes an endpoint to an Amazon SNS topic. If the endpoint type is HTTP/S or email, or if the endpoint and
+     * the topic are not in the same AWS account, the endpoint owner must the <code>ConfirmSubscription</code> action to
+     * confirm the subscription.
+     * </p>
+     * <p>
+     * You call the <code>ConfirmSubscription</code> action with the token from the subscription response. Confirmation
+     * tokens are valid for three days.
      * </p>
      * <p>
      * This action is throttled at 100 transactions per second (TPS).
@@ -793,9 +928,13 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException             Indicates an internal service error.
      * @throws NotFoundException                  Indicates that the requested resource does not exist.
      * @throws AuthorizationErrorException        Indicates that the user has been denied access to the requested resource.
+     * @throws InvalidSecurityException           The credential signature isn't valid. You must use an HTTPS endpoint and sign your request using
+     *                                            Signature Version 4.
+     * @throws SdkException                       Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                            catch all scenarios.
      * @throws SdkClientException                 If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                       Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.Subscribe
+     * @sample SnsClient.Subscribe
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/Subscribe" target="_top">AWS API
      * Documentation</a>
      */
@@ -822,9 +961,13 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * @throws InternalErrorException      Indicates an internal service error.
      * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
      * @throws NotFoundException           Indicates that the requested resource does not exist.
+     * @throws InvalidSecurityException    The credential signature isn't valid. You must use an HTTPS endpoint and sign your request using
+     *                                     Signature Version 4.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
      * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
      * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
-     * @sample AmazonSNS.Unsubscribe
+     * @sample SnsClient.Unsubscribe
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/Unsubscribe" target="_top">AWS API
      * Documentation</a>
      */
@@ -834,36 +977,120 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
     }
 
     /**
-     * List all tags added to the specified Amazon SNS topic.
+     * <p>
+     * List all tags added to the specified Amazon SNS topic. For an overview, see <a
+     * href="https://docs.aws.amazon.com/sns/latest/dg/sns-tags.html">Amazon SNS Tags</a> in the <i>Amazon Simple
+     * Notification Service Developer Guide</i>.
+     * </p>
      *
-     * @param request The originally executed request
-     * @return Result of the ListTagsForResource operation returned by the service
-     */
+     * @param listTagsForResourceRequest
+     * @return Result of the ListTagsForResource operation returned by the service.
+     * @throws ResourceNotFoundException   Can't tag resource. Verify that the topic exists.
+     * @throws TagPolicyException          The request doesn't comply with the IAM tag policy. Correct your request and then retry it.
+     * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
+     * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws ConcurrentAccessException   Can't perform multiple operations on a tag simultaneously. Perform the operations sequentially.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample SnsClient.ListTagsForResource
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/ListTagsForResource" target="_top">AWS API
+     *      Documentation</a>     */
     @Override
-    public ListTagsForResourceResponse listTagsForResource(ListTagsForResourceRequest request) {
-        return amazonSNSToBeExtended.listTagsForResource(request);
+    public ListTagsForResourceResponse listTagsForResource(ListTagsForResourceRequest listTagsForResourceRequest) {
+        return amazonSNSToBeExtended.listTagsForResource(listTagsForResourceRequest);
     }
 
     /**
-     * Add tags to the specified Amazon SNS topic. For an overview, see Amazon SNS Tags in the Amazon SNS Developer Guide.
+     * <p>
+     * Add tags to the specified Amazon SNS topic. For an overview, see <a
+     * href="https://docs.aws.amazon.com/sns/latest/dg/sns-tags.html">Amazon SNS Tags</a> in the <i>Amazon SNS Developer
+     * Guide</i>.
+     * </p>
+     * <p>
+     * When you use topic tags, keep the following guidelines in mind:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * Adding more than 50 tags to a topic isn't recommended.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * Tags don't have any semantic meaning. Amazon SNS interprets tags as character strings.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * Tags are case-sensitive.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * A new tag with a key identical to that of an existing tag overwrites the existing tag.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * Tagging actions are limited to 10 TPS per AWS account, per AWS region. If your application requires a higher
+     * throughput, file a <a
+     * href="https://console.aws.amazon.com/support/home#/case/create?issueType=technical">technical support
+     * request</a>.
+     * </p>
+     * </li>
+     * </ul>
      *
-     * @param request The originally executed request
+     * @param tagResourceRequest
      * @return Result of the TagResource operation returned by the service.
-     */
+     * @throws ResourceNotFoundException   Can't tag resource. Verify that the topic exists.
+     * @throws TagLimitExceededException   Can't add more than 50 tags to a topic.
+     * @throws StaleTagException           A tag has been added to a resource with the same ARN as a deleted resource. Wait a short while and then
+     *                                     retry the operation.
+     * @throws TagPolicyException          The request doesn't comply with the IAM tag policy. Correct your request and then retry it.
+     * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
+     * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws ConcurrentAccessException   Can't perform multiple operations on a tag simultaneously. Perform the operations sequentially.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample SnsClient.TagResource
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/TagResource" target="_top">AWS API
+     *      Documentation</a>     */
     @Override
-    public TagResourceResponse tagResource(TagResourceRequest request) {
-        return amazonSNSToBeExtended.tagResource(request);
+    public TagResourceResponse tagResource(TagResourceRequest tagResourceRequest) {
+        return amazonSNSToBeExtended.tagResource(tagResourceRequest);
     }
 
     /**
-     * Remove tags from the specified Amazon SNS topic. For an overview, see Amazon SNS Tags in the Amazon SNS Developer Guide.
+     * <p>
+     * Remove tags from the specified Amazon SNS topic. For an overview, see <a
+     * href="https://docs.aws.amazon.com/sns/latest/dg/sns-tags.html">Amazon SNS Tags</a> in the <i>Amazon SNS Developer
+     * Guide</i>.
+     * </p>
      *
-     * @param request The originally executed request
+     * @param untagResourceRequest
      * @return Result of the UntagResource operation returned by the service.
-     */
+     * @throws ResourceNotFoundException   Can't tag resource. Verify that the topic exists.
+     * @throws TagLimitExceededException   Can't add more than 50 tags to a topic.
+     * @throws StaleTagException           A tag has been added to a resource with the same ARN as a deleted resource. Wait a short while and then
+     *                                     retry the operation.
+     * @throws TagPolicyException          The request doesn't comply with the IAM tag policy. Correct your request and then retry it.
+     * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
+     * @throws AuthorizationErrorException Indicates that the user has been denied access to the requested resource.
+     * @throws ConcurrentAccessException   Can't perform multiple operations on a tag simultaneously. Perform the operations sequentially.
+     * @throws SdkException                Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *                                     catch all scenarios.
+     * @throws SdkClientException          If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws SnsException                Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample SnsClient.UntagResource
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/sns-2010-03-31/UntagResource" target="_top">AWS API
+     *      Documentation</a>     */
     @Override
-    public UntagResourceResponse untagResource(UntagResourceRequest request) {
-        return amazonSNSToBeExtended.untagResource(request);
+    public UntagResourceResponse untagResource(UntagResourceRequest untagResourceRequest) {
+        return amazonSNSToBeExtended.untagResource(untagResourceRequest);
     }
 
     @Override

--- a/src/main/java/software/amazon/sns/SNSExtendedClientConfiguration.java
+++ b/src/main/java/software/amazon/sns/SNSExtendedClientConfiguration.java
@@ -1,8 +1,8 @@
 package software.amazon.sns;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.payloadoffloading.PayloadStorageConfiguration;
+import software.amazon.payloadoffloading.ServerSideEncryptionStrategy;
 
 public class SNSExtendedClientConfiguration extends PayloadStorageConfiguration {
     static final int SNS_DEFAULT_MESSAGE_SIZE = 262144;
@@ -23,14 +23,14 @@ public class SNSExtendedClientConfiguration extends PayloadStorageConfiguration 
     }
 
     @Override
-    public SNSExtendedClientConfiguration withPayloadSupportEnabled(AmazonS3 s3, String s3BucketName) {
+    public SNSExtendedClientConfiguration withPayloadSupportEnabled(S3Client s3, String s3BucketName) {
         this.setPayloadSupportEnabled(s3, s3BucketName);
         return this;
     }
 
     @Override
-    public SNSExtendedClientConfiguration withSSEAwsKeyManagementParams(SSEAwsKeyManagementParams sseAwsKeyManagementParams) {
-        this.setSSEAwsKeyManagementParams(sseAwsKeyManagementParams);
+    public SNSExtendedClientConfiguration withServerSideEncryption(ServerSideEncryptionStrategy serverSideEncryptionStrategy) {
+        this.setServerSideEncryptionStrategy(serverSideEncryptionStrategy);
         return this;
     }
 

--- a/src/test/java/software/amazon/sns/AmazonSNSExtendedClientTest.java
+++ b/src/test/java/software/amazon/sns/AmazonSNSExtendedClientTest.java
@@ -5,14 +5,15 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.services.sns.AmazonSNS;
-import com.amazonaws.services.sns.AmazonSNSClient;
-import com.amazonaws.services.sns.model.MessageAttributeValue;
-import com.amazonaws.services.sns.model.PublishRequest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
 import software.amazon.payloadoffloading.Util;
 
 import java.util.Arrays;
@@ -32,14 +33,14 @@ public class AmazonSNSExtendedClientTest {
     // should be > 1 and << SNSExtendedClientConfiguration.SNS_DEFAULT_MESSAGE_SIZE
     private static final int ARBITRARY_SMALLER_THRESHOLD = 500;
 
-    private AmazonSNS extendedSnsWithDefaultConfig;
-    private AmazonSNS mockSnsBackend;
+    private SnsClient extendedSnsWithDefaultConfig;
+    private SnsClient mockSnsBackend;
     private AmazonS3 mockS3;
 
     @Before
     public void setupClient() {
         mockS3 = mock(AmazonS3.class);
-        mockSnsBackend = mock(AmazonSNS.class);
+        mockSnsBackend = mock(SnsClient.class);
         when(mockS3.putObject(any(PutObjectRequest.class))).thenReturn(null);
 
         SNSExtendedClientConfiguration snsExtendedClientConfiguration = new SNSExtendedClientConfiguration()
@@ -53,31 +54,31 @@ public class AmazonSNSExtendedClientTest {
     public void testPublishLargeMessageS3IsUsed() {
         String messageBody = generateStringWithLength(MORE_THAN_SNS_SIZE_LIMIT);
 
-        PublishRequest publishRequest = new PublishRequest(SNS_TOPIC_ARN, messageBody);
+        PublishRequest publishRequest = PublishRequest.builder().topicArn(SNS_TOPIC_ARN).message(messageBody).build();
         extendedSnsWithDefaultConfig.publish(publishRequest);
 
         verify(mockS3, times(1)).putObject(any(PutObjectRequest.class));
         ArgumentCaptor<PublishRequest> publishRequestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
         verify(mockSnsBackend, times(1)).publish(publishRequestCaptor.capture());
 
-        Map<String, MessageAttributeValue> attributes = publishRequestCaptor.getValue().getMessageAttributes();
-        Assert.assertEquals("Number", attributes.get(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME).getDataType());
+        Map<String, MessageAttributeValue> attributes = publishRequestCaptor.getValue().messageAttributes();
+        Assert.assertEquals("Number", attributes.get(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME).dataType());
 
-        Assert.assertEquals(messageBody.length(), (int) Integer.valueOf(attributes.get(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME).getStringValue()));
+        Assert.assertEquals(messageBody.length(), (int) Integer.valueOf(attributes.get(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME).stringValue()));
     }
 
     @Test
     public void testPublishSmallMessageS3IsNotUsed() {
         String messageBody = generateStringWithLength(SNSExtendedClientConfiguration.SNS_DEFAULT_MESSAGE_SIZE);
 
-        PublishRequest publishRequest = new PublishRequest(SNS_TOPIC_ARN, messageBody);
+        PublishRequest publishRequest = PublishRequest.builder().topicArn(SNS_TOPIC_ARN).message(messageBody).build();
         extendedSnsWithDefaultConfig.publish(publishRequest);
 
         verify(mockS3, never()).putObject(any(PutObjectRequest.class));
         ArgumentCaptor<PublishRequest> publishRequestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
         verify(mockSnsBackend, times(1)).publish(publishRequestCaptor.capture());
 
-        Map<String, MessageAttributeValue> attributes = publishRequestCaptor.getValue().getMessageAttributes();
+        Map<String, MessageAttributeValue> attributes = publishRequestCaptor.getValue().messageAttributes();
         Assert.assertTrue(attributes.isEmpty());
     }
 
@@ -86,9 +87,16 @@ public class AmazonSNSExtendedClientTest {
         String messageBody = generateStringWithLength(MORE_THAN_SNS_SIZE_LIMIT);
         SNSExtendedClientConfiguration snsExtendedClientConfiguration = new SNSExtendedClientConfiguration()
                 .withPayloadSupportDisabled();
-        AmazonSNS snsExtended = spy(new AmazonSNSExtendedClient(mockSnsBackend, snsExtendedClientConfiguration));
+        SnsClient snsExtended = spy(new AmazonSNSExtendedClient(mockSnsBackend, snsExtendedClientConfiguration));
 
-        PublishRequest publishRequest = new PublishRequest(SNS_TOPIC_ARN, messageBody);
+        PublishRequest publishRequest = PublishRequest.builder()
+            .topicArn(SNS_TOPIC_ARN)
+            .message(messageBody)
+            .overrideConfiguration(
+                AwsRequestOverrideConfiguration.builder()
+                    .putHeader(AmazonSNSExtendedClient.USER_AGENT_HEADER_NAME, AmazonSNSExtendedClient.USER_AGENT_HEADER)
+                    .build())
+            .build();
         snsExtended.publish(publishRequest);
 
         verify(mockS3, never()).putObject(any(PutObjectRequest.class));
@@ -99,8 +107,11 @@ public class AmazonSNSExtendedClientTest {
     public void testPublishMessageWithJSONMessageStructureThrowsAmazonClientException() {
         String messageBody = "{\"key1\":\"value1\",\"key2\":8.0}";
 
-        PublishRequest publishRequest = new PublishRequest(SNS_TOPIC_ARN, messageBody);
-        publishRequest.setMessageStructure(AmazonSNSExtendedClient.MULTIPLE_PROTOCOL_MESSAGE_STRUCTURE);
+        PublishRequest publishRequest = PublishRequest.builder()
+            .topicArn(SNS_TOPIC_ARN)
+            .message(messageBody)
+            .messageStructure(AmazonSNSExtendedClient.MULTIPLE_PROTOCOL_MESSAGE_STRUCTURE)
+            .build();
 
         try {
             extendedSnsWithDefaultConfig.publish(publishRequest);
@@ -118,9 +129,9 @@ public class AmazonSNSExtendedClientTest {
                 .withPayloadSupportEnabled(mockS3, S3_BUCKET_NAME)
                 .withAlwaysThroughS3(true);
 
-        AmazonSNS snsExtended = spy(new AmazonSNSExtendedClient(mock(AmazonSNSClient.class), snsExtendedClientConfiguration));
+        SnsClient snsExtended = spy(new AmazonSNSExtendedClient(mock(SnsClient.class), snsExtendedClientConfiguration));
 
-        snsExtended.publish(SNS_TOPIC_ARN, messageBody);
+        snsExtended.publish(PublishRequest.builder().topicArn(SNS_TOPIC_ARN).message(messageBody).build());
 
         verify(mockS3, times(1)).putObject(any(PutObjectRequest.class));
     }
@@ -132,9 +143,9 @@ public class AmazonSNSExtendedClientTest {
                 .withPayloadSupportEnabled(mockS3, S3_BUCKET_NAME)
                 .withPayloadSizeThreshold(ARBITRARY_SMALLER_THRESHOLD);
 
-        AmazonSNS snsExtended = spy(new AmazonSNSExtendedClient(mock(AmazonSNSClient.class), snsExtendedClientConfiguration));
+        SnsClient snsExtended = spy(new AmazonSNSExtendedClient(mock(SnsClient.class), snsExtendedClientConfiguration));
 
-        snsExtended.publish(SNS_TOPIC_ARN, messageBody);
+        snsExtended.publish(PublishRequest.builder().topicArn(SNS_TOPIC_ARN).message(messageBody).build());
         verify(mockS3, times(1)).putObject(any(PutObjectRequest.class));
     }
 
@@ -142,14 +153,17 @@ public class AmazonSNSExtendedClientTest {
     public void testPublishRequestDoesNotAlterPublishRequest() {
         String messageBody = generateStringWithLength(MORE_THAN_SNS_SIZE_LIMIT);
         HashMap<String, MessageAttributeValue> attrs = new HashMap<>();
-        attrs.put("SampleKey", new MessageAttributeValue().withStringValue("value"));
+        attrs.put("SampleKey", MessageAttributeValue.builder().stringValue("value").build());
 
-        PublishRequest publishRequest = new PublishRequest(SNS_TOPIC_ARN, messageBody);
-        publishRequest.setMessageAttributes(attrs);
+        PublishRequest publishRequest = PublishRequest.builder()
+            .topicArn(SNS_TOPIC_ARN)
+            .message(messageBody)
+            .messageAttributes(attrs)
+            .build();
         extendedSnsWithDefaultConfig.publish(publishRequest);
 
-        Assert.assertEquals(messageBody, publishRequest.getMessage());
-        Assert.assertEquals(attrs, publishRequest.getMessageAttributes());
+        Assert.assertEquals(messageBody, publishRequest.message());
+        Assert.assertEquals(attrs, publishRequest.messageAttributes());
     }
 
     @Test
@@ -157,7 +171,7 @@ public class AmazonSNSExtendedClientTest {
         when(mockS3.putObject(any(PutObjectRequest.class))).thenThrow(AmazonServiceException.class);
 
         String messageBody = generateStringWithLength(MORE_THAN_SNS_SIZE_LIMIT);
-        PublishRequest publishRequest = new PublishRequest(SNS_TOPIC_ARN, messageBody);
+        PublishRequest publishRequest = PublishRequest.builder().topicArn(SNS_TOPIC_ARN).message(messageBody).build();
 
         try {
             extendedSnsWithDefaultConfig.publish(publishRequest);
@@ -173,7 +187,7 @@ public class AmazonSNSExtendedClientTest {
         when(mockS3.putObject(any(PutObjectRequest.class))).thenThrow(AmazonClientException.class);
 
         String messageBody = generateStringWithLength(MORE_THAN_SNS_SIZE_LIMIT);
-        PublishRequest publishRequest = new PublishRequest(SNS_TOPIC_ARN, messageBody);
+        PublishRequest publishRequest = PublishRequest.builder().topicArn(SNS_TOPIC_ARN).message(messageBody).build();
 
         try {
             extendedSnsWithDefaultConfig.publish(publishRequest);
@@ -188,11 +202,18 @@ public class AmazonSNSExtendedClientTest {
     public void testThrowAmazonClientExceptionWhenReservedAttributeNameIsAlreadyUsed() {
         String messageBody = generateStringWithLength(MORE_THAN_SNS_SIZE_LIMIT);
 
-        MessageAttributeValue messageAttributeValue = new MessageAttributeValue();
-        messageAttributeValue.setDataType("Number");
-        messageAttributeValue.setStringValue(Util.getStringSizeInBytes(messageBody) + "");
-        PublishRequest publishRequest = new PublishRequest(SNS_TOPIC_ARN, messageBody);
-        publishRequest.addMessageAttributesEntry(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME, messageAttributeValue);
+        MessageAttributeValue messageAttributeValue = MessageAttributeValue.builder()
+            .dataType("Number")
+            .stringValue(Util.getStringSizeInBytes(messageBody) + "")
+            .build();
+        HashMap<String, MessageAttributeValue> attrs = new HashMap<>();
+        attrs.put(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME, messageAttributeValue);
+
+        PublishRequest publishRequest = PublishRequest.builder()
+            .topicArn(SNS_TOPIC_ARN)
+            .message(messageBody)
+            .messageAttributes(attrs)
+            .build();
 
         try {
             extendedSnsWithDefaultConfig.publish(publishRequest);
@@ -212,11 +233,14 @@ public class AmazonSNSExtendedClientTest {
         HashMap<String, MessageAttributeValue> attrs = new HashMap<>();
 
         for (int index = 0; index < attributeNumber; index++) {
-            attrs.put("key" + index, new MessageAttributeValue().withDataType("String").withStringValue("value" + index));
+            attrs.put("key" + index, MessageAttributeValue.builder().dataType("String").stringValue("value" + index).build());
         }
 
-        PublishRequest publishRequest = new PublishRequest(SNS_TOPIC_ARN, messageBody);
-        publishRequest.setMessageAttributes(attrs);
+        PublishRequest publishRequest = PublishRequest.builder()
+            .topicArn(SNS_TOPIC_ARN)
+            .message(messageBody)
+            .messageAttributes(attrs)
+            .build();
 
         try {
             extendedSnsWithDefaultConfig.publish(publishRequest);
@@ -235,11 +259,15 @@ public class AmazonSNSExtendedClientTest {
         String attributeKey = generateStringWithLength(MORE_THAN_SNS_SIZE_LIMIT);
         String attributeValue = generateStringWithLength(LESS_THAN_SNS_SIZE_LIMIT);
 
-        MessageAttributeValue messageAttributeValue = new MessageAttributeValue();
-        messageAttributeValue.withStringValue(attributeValue);
+        MessageAttributeValue messageAttributeValue = MessageAttributeValue.builder().stringValue(attributeValue).build();
+        HashMap<String, MessageAttributeValue> attrs = new HashMap<>();
+        attrs.put(attributeKey, messageAttributeValue);
 
-        PublishRequest publishRequest = new PublishRequest(SNS_TOPIC_ARN, messageBody);
-        publishRequest.addMessageAttributesEntry(attributeKey, messageAttributeValue);
+        PublishRequest publishRequest = PublishRequest.builder()
+            .topicArn(SNS_TOPIC_ARN)
+            .message(messageBody)
+            .messageAttributes(attrs)
+            .build();
 
         Long expectedSize = Util.getStringSizeInBytes(attributeKey) + Util.getStringSizeInBytes(attributeValue);
 
@@ -260,11 +288,15 @@ public class AmazonSNSExtendedClientTest {
         String attributeKey = generateStringWithLength(LESS_THAN_SNS_SIZE_LIMIT);
         String attributeValue = generateStringWithLength(MORE_THAN_SNS_SIZE_LIMIT);
 
-        MessageAttributeValue messageAttributeValue = new MessageAttributeValue();
-        messageAttributeValue.withStringValue(attributeValue);
+        MessageAttributeValue messageAttributeValue = MessageAttributeValue.builder().stringValue(attributeValue).build();
+        HashMap<String, MessageAttributeValue> attrs = new HashMap<>();
+        attrs.put(attributeKey, messageAttributeValue);
 
-        PublishRequest publishRequest = new PublishRequest(SNS_TOPIC_ARN, messageBody);
-        publishRequest.addMessageAttributesEntry(attributeKey, messageAttributeValue);
+        PublishRequest publishRequest = PublishRequest.builder()
+            .topicArn(SNS_TOPIC_ARN)
+            .message(messageBody)
+            .messageAttributes(attrs)
+            .build();
 
         long expectedSize = Util.getStringSizeInBytes(attributeKey) + Util.getStringSizeInBytes(attributeValue);
 


### PR DESCRIPTION
Henter inn endringer fra branch hos awslabs, og oppdaterer denne til å bruke sqs extended client 2.0.1. Endringer utover dette kommer fra https://github.com/awslabs/amazon-sns-java-extended-client-lib/pull/6